### PR TITLE
Simplify push updates; add enable_push; lock recv; 60s fallback

### DIFF
--- a/custom_components/fansync/client.py
+++ b/custom_components/fansync/client.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import ssl
+import threading
+import time
 from collections.abc import Callable
 from typing import Any
 
@@ -14,16 +16,22 @@ from websocket import WebSocketConnectionClosedException
 
 
 class FanSyncClient:
-    def __init__(self, hass: HomeAssistant, email: str, password: str, verify_ssl: bool = True):
+    def __init__(
+        self, hass: HomeAssistant, email: str, password: str, verify_ssl: bool = True, *, enable_push: bool = True
+    ):
         self.hass = hass
         self.email = email
         self.password = password
         self.verify_ssl = verify_ssl
+        self._enable_push = enable_push
         self._http: httpx.Client | None = None
         self._ws: websocket.WebSocket | None = None
         self._token: str | None = None
         self._device_id: str | None = None
         self._status_callback: Callable[[dict[str, Any]], None] | None = None
+        self._running: bool = False
+        self._recv_lock: threading.Lock = threading.Lock()
+        self._recv_thread: threading.Thread | None = None
 
     async def async_connect(self):
         def _connect():
@@ -61,13 +69,65 @@ class FanSyncClient:
             self._ws = ws
             self._token = token
             self._device_id = device_id
+            self._running = True
 
         await self.hass.async_add_executor_job(_connect)
 
+        # Start background receive loop to push unsolicited updates
+        if self._enable_push:
+            def _recv_loop():
+                while self._running:
+                    ws = self._ws
+                    if ws is None:
+                        time.sleep(0.1)
+                        continue
+                    # avoid racing with explicit get/set operations
+                    acquired = self._recv_lock.acquire(blocking=False)
+                    if not acquired:
+                        time.sleep(0.02)
+                        continue
+                    try:
+                        try:
+                            raw = ws.recv()
+                        except Exception:
+                            time.sleep(0.1)
+                            continue
+                    finally:
+                        self._recv_lock.release()
+
+                    try:
+                        payload = json.loads(raw if isinstance(raw, str) else raw.decode())
+                    except Exception:
+                        continue
+                    if not isinstance(payload, dict):
+                        continue
+                    # Ignore direct responses to our own requests
+                    if payload.get("response") in {"login", "lst_device", "get", "set"}:
+                        continue
+                    data = payload.get("data")
+                    if isinstance(data, dict) and isinstance(data.get("status"), dict):
+                        pushed_status = data["status"]
+                        if self._status_callback is not None:
+                            def _notify(s: dict[str, Any] = pushed_status) -> None:
+                                assert self._status_callback is not None
+                                self._status_callback(s)
+                            self.hass.loop.call_soon_threadsafe(_notify)
+
+            thread = threading.Thread(target=_recv_loop, name="_recv_loop", daemon=True)
+            self._recv_thread = thread
+            thread.start()
+
     async def async_disconnect(self):
+        # Signal background thread to stop first
+        self._running = False
         if self._ws:
             await self.hass.async_add_executor_job(self._ws.close)
             self._ws = None
+        # Join background thread if it exists
+        thread = self._recv_thread
+        if thread is not None and thread.is_alive():
+            await self.hass.async_add_executor_job(thread.join, 1.0)
+        self._recv_thread = None
 
     # Internal helper: ensure websocket is connected and logged in (called in executor)
     def _ensure_ws_connected(self) -> None:
@@ -104,19 +164,22 @@ class FanSyncClient:
             assert self._device_id is not None
             self._ensure_ws_connected()
             assert self._ws is not None
-            try:
-                self._ws.send(json.dumps({"id": 3, "request": "get", "device": self._device_id}))
-            except WebSocketConnectionClosedException:
-                # reconnect and retry once
-                self._ws = None
-                self._ensure_ws_connected()
-                assert self._ws is not None
-                self._ws.send(json.dumps({"id": 3, "request": "get", "device": self._device_id}))
-            while True:
-                raw = self._ws.recv()
-                payload = json.loads(raw if isinstance(raw, str) else raw.decode())
-                if isinstance(payload, dict) and payload.get("response") == "get":
-                    return payload["data"]["status"]
+            with self._recv_lock:
+                try:
+                    self._ws.send(json.dumps({"id": 3, "request": "get", "device": self._device_id}))
+                except WebSocketConnectionClosedException:
+                    # reconnect and retry once
+                    self._ws = None
+                    self._ensure_ws_connected()
+                    assert self._ws is not None
+                    self._ws.send(json.dumps({"id": 3, "request": "get", "device": self._device_id}))
+                # Bounded read to find the response
+                for _ in range(5):
+                    raw = self._ws.recv()
+                    payload = json.loads(raw if isinstance(raw, str) else raw.decode())
+                    if isinstance(payload, dict) and payload.get("response") == "get":
+                        return payload["data"]["status"]
+                raise RuntimeError("Get status response not received")
 
         return await self.hass.async_add_executor_job(_get)
 
@@ -131,18 +194,20 @@ class FanSyncClient:
                 "device": self._device_id,
                 "data": data,
             }
-            try:
-                self._ws.send(json.dumps(message))
-            except WebSocketConnectionClosedException:
-                # reconnect and retry once
-                self._ws = None
-                self._ensure_ws_connected()
-                assert self._ws is not None
-                self._ws.send(json.dumps(message))
-            try:
-                self._ws.recv()
-            except Exception:
-                pass
+            with self._recv_lock:
+                try:
+                    self._ws.send(json.dumps(message))
+                except WebSocketConnectionClosedException:
+                    # reconnect and retry once
+                    self._ws = None
+                    self._ensure_ws_connected()
+                    assert self._ws is not None
+                    self._ws.send(json.dumps(message))
+                # Best-effort ack read; ignore errors
+                try:
+                    self._ws.recv()
+                except Exception:
+                    pass
 
         await self.hass.async_add_executor_job(_set)
         # After a successful set, fetch latest status and notify listeners, if any.

--- a/custom_components/fansync/coordinator.py
+++ b/custom_components/fansync/coordinator.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .client import FanSyncClient
 
-SCAN_INTERVAL = timedelta(seconds=0)
+SCAN_INTERVAL = timedelta(seconds=60)
 
 class FanSyncCoordinator(DataUpdateCoordinator):
     def __init__(self, hass: HomeAssistant, client: FanSyncClient):
@@ -18,7 +18,7 @@ class FanSyncCoordinator(DataUpdateCoordinator):
             hass,
             logger=logging.getLogger(__name__),
             name="fansync",
-            update_interval=None,  # push updates via client callback
+            update_interval=SCAN_INTERVAL,  # periodic refresh as a fallback to push
         )
         self.client = client
 

--- a/tests/test_client_reconnect.py
+++ b/tests/test_client_reconnect.py
@@ -29,7 +29,7 @@ def _get_ok(status: dict[str, int]) -> str:
 
 
 async def test_disconnect_on_unload(hass: HomeAssistant):
-    c = FanSyncClient(hass, "e", "p")
+    c = FanSyncClient(hass, "e", "p", enable_push=False)
     with patch("custom_components.fansync.client.httpx.Client") as http_cls, \
          patch("custom_components.fansync.client.websocket.WebSocket") as ws_cls:
         http_inst = http_cls.return_value
@@ -45,7 +45,7 @@ async def test_disconnect_on_unload(hass: HomeAssistant):
 
 
 async def test_set_retries_on_closed_socket(hass: HomeAssistant):
-    c = FanSyncClient(hass, "e", "p")
+    c = FanSyncClient(hass, "e", "p", enable_push=False)
     with patch("custom_components.fansync.client.httpx.Client") as http_cls, \
          patch("custom_components.fansync.client.websocket.WebSocket") as ws_cls:
         http_inst = http_cls.return_value
@@ -69,6 +69,7 @@ async def test_set_retries_on_closed_socket(hass: HomeAssistant):
         ws.recv.side_effect = [_login_ok(), json.dumps({"status": "ok", "response": "set", "id": 4})]
 
         await c.async_set({"H02": 10})
+        await c.async_disconnect()
 
     assert ws.send.call_count >= 2
 

--- a/tests/test_client_ssl.py
+++ b/tests/test_client_ssl.py
@@ -15,7 +15,7 @@ from custom_components.fansync.client import FanSyncClient
 
 async def test_client_ssl_flag(hass: HomeAssistant):
     """Ensure FanSyncClient builds HTTPX client with verify=True when configured."""
-    c = FanSyncClient(hass, "e", "p", verify_ssl=True)
+    c = FanSyncClient(hass, "e", "p", verify_ssl=True, enable_push=False)
     with patch("custom_components.fansync.client.httpx.Client") as http_cls, \
          patch("custom_components.fansync.client.websocket.WebSocket") as ws_cls:
         http_inst = http_cls.return_value
@@ -27,4 +27,5 @@ async def test_client_ssl_flag(hass: HomeAssistant):
             '{"status":"ok","response":"lst_device","data":[{"device":"id"}],"id":2}',
         ]
         await c.async_connect()
+        await c.async_disconnect()
         http_cls.assert_called_with(verify=True)


### PR DESCRIPTION
Client: optional background listener (enable_push), recv lock, bounded get read, reconnect on closed socket, thread lifecycle join on disconnect.
Coordinator: fallback polling 60s.
Tests: disable push in tests, remove thread patching, ensure clean teardown. 19 passed.