### PR TITLE
feat(fansync): immediate HA updates via set ACK; optional push listener

### DIFF
--- a/tests/test_client_core.py
+++ b/tests/test_client_core.py
@@ -108,6 +108,36 @@ async def test_async_set_triggers_callback(hass: HomeAssistant):
     assert seen and seen[-1].get("H02") == 55
 
 
+async def test_async_set_uses_ack_status_when_present(hass: HomeAssistant):
+    c = FanSyncClient(hass, "e", "p", verify_ssl=True, enable_push=False)
+    with patch("custom_components.fansync.client.httpx.Client") as http_cls, \
+         patch("custom_components.fansync.client.websocket.WebSocket") as ws_cls:
+        http_inst = http_cls.return_value
+        http_inst.post.return_value = type("R", (), {"raise_for_status": lambda self: None, "json": lambda self: {"token": "t"}})()
+        ws = ws_cls.return_value
+        ws.connect.return_value = None
+        # login, list, then set ACK with embedded status (no subsequent get response provided)
+        ws.recv.side_effect = [
+            _login_ok(),
+            _lst_device_ok("id"),
+            json.dumps({
+                "status": "ok",
+                "response": "set",
+                "id": 4,
+                "data": {"status": {"H00": 0, "H02": 1}},
+            }),
+        ]
+
+        seen: list[dict[str, int]] = []
+        c.set_status_callback(lambda s: seen.append(s))
+
+        await c.async_connect()
+        await c.async_set({"H00": 0})
+        await hass.async_block_till_done()
+
+    # Should have used ACK status directly without needing a separate get
+    assert seen and seen[-1].get("H00") == 0 and seen[-1].get("H02") == 1
+
 async def test_connect_ws_login_failure_raises(hass: HomeAssistant):
     c = FanSyncClient(hass, "e", "p")
     with patch("custom_components.fansync.client.httpx.Client") as http_cls, \


### PR DESCRIPTION
Client: parse set ACK status and push immediately; fallback to get if absent Add enable_push flag; background recv thread guarded by lock; clean shutdown Simplify get to bounded read under lock; reconnect on closed socket Coordinator: set fallback polling to 60s
Tests: disable push in unit tests; add ACK-status test; all 20 passing