### PR TITLE
feat: improve connection resilience and user-facing errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Note: This integration is not in the HACS default registry. Add it as a custom r
 8) Add the integration: Settings → Devices & Services → Add integration → “FanSync”.
 
 See also: [HACS: Custom repositories](https://hacs.xyz/docs/use/custom_repositories/)
+• Issues: [Open or track issues](https://github.com/tjbaker/homeassistant-fansync/issues)
+• PRs: [Create a pull request](https://github.com/tjbaker/homeassistant-fansync/pulls)
 
 ### Manual
 
@@ -46,8 +48,8 @@ See also: [HACS: Custom repositories](https://hacs.xyz/docs/use/custom_repositor
 | Email       | FanSync account email                                        | –       |
 | Password    | FanSync account password                                     | –       |
 | Verify SSL  | Verify HTTPS certificates when connecting to FanSync cloud   | True    |
-| HTTP timeout (s) | HTTP connect/read timeout used during login/token refresh     | 10      |
-| WebSocket timeout (s) | WebSocket connect/recv timeout for realtime channel         | 15      |
+| HTTP timeout (s) | HTTP connect/read timeout used during login/token refresh     | 20      |
+| WebSocket timeout (s) | WebSocket connect/recv timeout for realtime channel         | 30      |
 
 
 ### Options
@@ -57,12 +59,12 @@ Push-first updates are used by default. A low-frequency fallback poll can be con
 | Option                 | Description                                                       | Default |
 |------------------------|-------------------------------------------------------------------|---------|
 | fallback_poll_seconds  | Poll interval in seconds when push is unavailable (0 disables).  | 60      |
-| http_timeout_seconds   | HTTP connect/read timeout (seconds)                               | 10      |
-| ws_timeout_seconds     | WebSocket connect/recv timeout (seconds)                          | 15      |
+| http_timeout_seconds   | HTTP connect/read timeout (seconds)                               | 20      |
+| ws_timeout_seconds     | WebSocket connect/recv timeout (seconds)                          | 30      |
 
 Set via: Settings → Devices & Services → FanSync → Configure → Options.
 - Poll interval allowed range: 15–600 seconds (0 disables)
-- Timeout ranges: 5–60 seconds (HTTP and WebSocket)
+- Timeout ranges: 5–120 seconds (HTTP and WebSocket)
 
 ## Troubleshooting
 
@@ -78,16 +80,15 @@ Reference: Home Assistant docs: https://www.home-assistant.io/docs/configuration
 
 ## Contributing
 
-See `CONTRIBUTING.md` for development setup, lint/format, commit conventions, and PR guidance. For detailed test suite info and commands, see `tests/README.md`.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, lint/format, commit conventions, and PR guidance. For detailed test suite info and commands, see [tests/README.md](tests/README.md).
 
  
 
 ## License
 
-Apache-2.0 (see `LICENSE`).
+Apache-2.0 (see [LICENSE](LICENSE)).
 
 ## Acknowledgments
 
 - Reverse‑engineering notes and sample payloads that informed this work were
-  originally published in rotinom/fansync:
-  https://github.com/rotinom/fansync
+  originally published in [rotinom/fansync](https://github.com/rotinom/fansync).

--- a/custom_components/fansync/const.py
+++ b/custom_components/fansync/const.py
@@ -51,14 +51,19 @@ FALLBACK_POLL_SECONDS = 30
 
 # Timeouts
 # HTTP timeouts apply to connect/read for login and token refresh
-DEFAULT_HTTP_TIMEOUT_SECS = 10
+DEFAULT_HTTP_TIMEOUT_SECS = 20
 MIN_HTTP_TIMEOUT_SECS = 5
-MAX_HTTP_TIMEOUT_SECS = 60
+MAX_HTTP_TIMEOUT_SECS = 120
 
 # WebSocket timeout for connect/recv operations
-DEFAULT_WS_TIMEOUT_SECS = 15
+DEFAULT_WS_TIMEOUT_SECS = 30
 MIN_WS_TIMEOUT_SECS = 5
-MAX_WS_TIMEOUT_SECS = 60
+MAX_WS_TIMEOUT_SECS = 120
+
+
+# WebSocket login retry settings
+WS_LOGIN_RETRY_ATTEMPTS = 2
+WS_LOGIN_RETRY_BACKOFF_SEC = 1.0
 
 
 def clamp_percentage(value: int) -> int:

--- a/custom_components/fansync/translations/en.json
+++ b/custom_components/fansync/translations/en.json
@@ -14,7 +14,7 @@
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect to Fanimation servers. Check your network connection or try again later.",
+      "cannot_connect": "Failed to connect. Check your network or increase the HTTP/WebSocket timeouts in setup or Options, then try again.",
       "invalid_auth": "Invalid email or password. Please check your credentials.",
       "no_devices": "No FanSync devices found on your account. Please verify devices are registered in the Fanimation app.",
       "unknown": "An unexpected error occurred. Please check the logs for details."

--- a/tests/test_config_flow_errors.py
+++ b/tests/test_config_flow_errors.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from unittest.mock import Mock, patch
 
 import httpx
+from websocket import WebSocketTimeoutException
 from homeassistant import data_entry_flow
 
 
@@ -27,6 +28,24 @@ async def test_config_flow_cannot_connect(hass):
     with patch(
         "custom_components.fansync.config_flow.FanSyncClient.async_connect",
         side_effect=httpx.ConnectError("Connection refused"),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"email": "e", "password": "p", "verify_ssl": True},
+        )
+
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
+    assert result2["errors"].get("base") == "cannot_connect"
+
+
+async def test_config_flow_ws_timeout_maps_cannot_connect(hass):
+    # Start the config flow via Home Assistant to get a mutable context
+    result = await hass.config_entries.flow.async_init("fansync", context={"source": "user"})
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+
+    with patch(
+        "custom_components.fansync.config_flow.FanSyncClient.async_connect",
+        side_effect=WebSocketTimeoutException("Connection timed out"),
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -39,8 +39,8 @@ async def test_config_flow_passes_default_timeouts(hass, ensure_fansync_importab
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     # Ensure the constructor was given default timeout values
     _, kwargs = client_cls.call_args
-    assert kwargs.get("http_timeout_s") == 10
-    assert kwargs.get("ws_timeout_s") == 15
+    assert kwargs.get("http_timeout_s") == 20
+    assert kwargs.get("ws_timeout_s") == 30
 
 
 async def test_config_flow_passes_custom_timeouts(hass, ensure_fansync_importable):


### PR DESCRIPTION
- Client: add one-shot WebSocket connect/login retry on transient timeout (1s backoff)
- Config flow: map WebSocket timeouts/errors to cannot_connect; clearer logs
- Timeouts: raise defaults (HTTP 20s, WS 30s) and increase max to 120s
- Translations: neutral cannot_connect wording (HTTP/WebSocket)
- Docs: update README defaults/ranges and troubleshooting
- Tests: add WS-timeout mapping and WS-retry tests; update timeout expectations

Potentially fixes: #48, #71