### PR TITLE
fix: add debug logging for device profile caching

### DIFF
--- a/custom_components/fansync/client.py
+++ b/custom_components/fansync/client.py
@@ -427,6 +427,14 @@ class FanSyncClient:
                                 prof = data_obj.get("profile")
                                 if isinstance(prof, dict):
                                     self._device_profile[did] = prof
+                                    if _LOGGER.isEnabledFor(logging.DEBUG):
+                                        _LOGGER.debug(
+                                            "profile cached for %s: keys=%s",
+                                            did,
+                                            list(prof.keys()),
+                                        )
+                                elif _LOGGER.isEnabledFor(logging.DEBUG):
+                                    _LOGGER.debug("no profile in response for %s", did)
                         except Exception as exc:
                             if _LOGGER.isEnabledFor(logging.DEBUG):
                                 _LOGGER.debug("profile cache failed for %s: %s", did, exc)


### PR DESCRIPTION
- Log when profile is successfully cached with keys list
- Log when profile is missing from get response
- Helps diagnose missing device attributes (MAC, firmware, model)
- Related to device metadata not appearing in UI