### PR TITLE
fix: add detailed logging for set command ack handling

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -8,6 +8,11 @@ Any changes should be made there; this file syncs automatically via pre-commit h
 - Follow PEP 8 principles; Black/Ruff are authoritative for enforcement.
 - Optimize for clarity and readability; prefer explicit types where helpful.
 - Prefer union syntax in isinstance checks (e.g., int | str) over tuples.
+- Type Annotations:
+  - Always add type hints to function/method parameters and return types
+  - Use modern Python 3.10+ syntax: `X | None` instead of `Optional[X]`
+  - In tests, annotate fixtures: `hass: HomeAssistant`, `caplog: pytest.LogCaptureFixture`
+  - Add return types even for simple functions: `-> None`, `-> str`, `-> dict[str, Any]`
 
 # Imports
 - Organize imports consistent with Ruff isort settings.
@@ -60,6 +65,11 @@ Any changes should be made there; this file syncs automatically via pre-commit h
 - Ensure tests clean up background threads/tasks (call async_disconnect on FanSyncClient).
 - Use Home Assistant's config flow test helpers (hass.config_entries.flow.async_init) instead of
   directly instantiating flow classes.
+- Type annotations in tests:
+  - Always annotate test function parameters: `hass: HomeAssistant`, `caplog: pytest.LogCaptureFixture`
+  - Always add return type `-> None` to async test functions
+  - Import HomeAssistant from homeassistant.core
+  - Import pytest for LogCaptureFixture type hint
 
 # Git / Commits
 - Commit message subject MUST be ≤ 72 characters (to avoid GitHub truncation).
@@ -129,6 +139,8 @@ Any changes should be made there; this file syncs automatically via pre-commit h
 - Use appropriate format specifiers: %.0f for floats, %d for ints.
 - Prefer direct callable references over lambda: x when lambda just wraps a function.
 - Walrus operator (:=) is acceptable but prefer simpler code if formatters conflict.
+- Use bare `raise` instead of `raise exc` when re-raising exceptions to preserve tracebacks.
+- Extract magic numbers and hardcoded strings to named constants in const.py.
 
 # Performance
 - Guard expensive debug operations with `if _LOGGER.isEnabledFor(logging.DEBUG):`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,6 +8,11 @@ Any changes should be made there; this file syncs automatically via pre-commit h
 - Follow PEP 8 principles; Black/Ruff are authoritative for enforcement.
 - Optimize for clarity and readability; prefer explicit types where helpful.
 - Prefer union syntax in isinstance checks (e.g., int | str) over tuples.
+- Type Annotations:
+  - Always add type hints to function/method parameters and return types
+  - Use modern Python 3.10+ syntax: `X | None` instead of `Optional[X]`
+  - In tests, annotate fixtures: `hass: HomeAssistant`, `caplog: pytest.LogCaptureFixture`
+  - Add return types even for simple functions: `-> None`, `-> str`, `-> dict[str, Any]`
 
 # Imports
 - Organize imports consistent with Ruff isort settings.
@@ -60,6 +65,11 @@ Any changes should be made there; this file syncs automatically via pre-commit h
 - Ensure tests clean up background threads/tasks (call async_disconnect on FanSyncClient).
 - Use Home Assistant's config flow test helpers (hass.config_entries.flow.async_init) instead of
   directly instantiating flow classes.
+- Type annotations in tests:
+  - Always annotate test function parameters: `hass: HomeAssistant`, `caplog: pytest.LogCaptureFixture`
+  - Always add return type `-> None` to async test functions
+  - Import HomeAssistant from homeassistant.core
+  - Import pytest for LogCaptureFixture type hint
 
 # Git / Commits
 - Commit message subject MUST be ≤ 72 characters (to avoid GitHub truncation).
@@ -129,6 +139,8 @@ Any changes should be made there; this file syncs automatically via pre-commit h
 - Use appropriate format specifiers: %.0f for floats, %d for ints.
 - Prefer direct callable references over lambda: x when lambda just wraps a function.
 - Walrus operator (:=) is acceptable but prefer simpler code if formatters conflict.
+- Use bare `raise` instead of `raise exc` when re-raising exceptions to preserve tracebacks.
+- Extract magic numbers and hardcoded strings to named constants in const.py.
 
 # Performance
 - Guard expensive debug operations with `if _LOGGER.isEnabledFor(logging.DEBUG):`.

--- a/tests/test_profile_logging.py
+++ b/tests/test_profile_logging.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Trevor Baker, all rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test device profile caching debug logging."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from custom_components.fansync.client import FanSyncClient
+
+
+@pytest.mark.asyncio
+async def test_profile_cached_debug_logging(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test debug logging when profile is successfully cached."""
+    client = FanSyncClient(hass, "test@example.com", "password", verify_ssl=False)
+
+    try:
+        # Mock WebSocket and HTTP responses with profile data
+        mock_ws = MagicMock()
+        mock_ws.recv.return_value = (
+            '{"response": "get", "id": 3, "data": {"status": {"H00": 0}, '
+            '"profile": {"module": {"mac_address": "AA:BB:CC:DD:EE:FF", '
+            '"firmware_version": "1.2.3"}, "esh": {"model": "TestFan", "brand": "TestBrand"}}}}'
+        )
+
+        with (
+            patch.object(client, "_ws", mock_ws),
+            patch.object(client, "_recv_lock", MagicMock()),
+            patch.object(client, "_ensure_ws_connected"),
+        ):
+            client._device_id = "test_device_123"
+
+            # Enable debug logging
+            with caplog.at_level("DEBUG", logger="custom_components.fansync.client"):
+                await client.async_get_status()
+
+            # Verify profile cached message was logged
+            assert any(
+                "profile cached for test_device_123" in record.message and "keys=" in record.message
+                for record in caplog.records
+            )
+    finally:
+        await client.async_disconnect()
+
+
+@pytest.mark.asyncio
+async def test_no_profile_debug_logging(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test debug logging when profile is missing from response."""
+    client = FanSyncClient(hass, "test@example.com", "password", verify_ssl=False)
+
+    try:
+        # Mock WebSocket response WITHOUT profile data
+        mock_ws = MagicMock()
+        mock_ws.recv.return_value = '{"response": "get", "id": 3, "data": {"status": {"H00": 0}}}'
+
+        with (
+            patch.object(client, "_ws", mock_ws),
+            patch.object(client, "_recv_lock", MagicMock()),
+            patch.object(client, "_ensure_ws_connected"),
+        ):
+            client._device_id = "test_device_456"
+
+            # Enable debug logging
+            with caplog.at_level("DEBUG", logger="custom_components.fansync.client"):
+                await client.async_get_status()
+
+            # Verify "no profile" message was logged
+            assert any(
+                "no profile in response for test_device_456" in record.message
+                for record in caplog.records
+            )
+    finally:
+        await client.async_disconnect()
+
+
+@pytest.mark.asyncio
+async def test_profile_keys_logged_correctly(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that profile keys are logged in the correct format."""
+    client = FanSyncClient(hass, "test@example.com", "password", verify_ssl=False)
+
+    try:
+        # Mock WebSocket with specific profile keys
+        mock_ws = MagicMock()
+        mock_ws.recv.return_value = (
+            '{"response": "get", "id": 3, "data": {"status": {"H00": 1}, '
+            '"profile": {"module": {}, "esh": {}, "custom_key": "value"}}}'
+        )
+
+        with (
+            patch.object(client, "_ws", mock_ws),
+            patch.object(client, "_recv_lock", MagicMock()),
+            patch.object(client, "_ensure_ws_connected"),
+        ):
+            client._device_id = "test_device_789"
+
+            # Enable debug logging
+            with caplog.at_level("DEBUG", logger="custom_components.fansync.client"):
+                await client.async_get_status()
+
+            # Verify keys are logged as a list
+            profile_log = [
+                record.message
+                for record in caplog.records
+                if "profile cached for test_device_789" in record.message
+            ]
+            assert len(profile_log) == 1
+            # Should contain all expected profile keys
+            assert all(key in profile_log[0] for key in ["module", "esh", "custom_key"])
+    finally:
+        await client.async_disconnect()


### PR DESCRIPTION
- Log when waiting for set ack response
- Log when response is received
- Log response type if not a set ack
- Log parse and recv failures with exception types
- Helps diagnose 30-second timeouts on fan control commands