### PR TITLE
fix: handle WebSocket timeouts gracefully and fix device metadata timing

### DIFF
--- a/custom_components/fansync/__init__.py
+++ b/custom_components/fansync/__init__.py
@@ -84,13 +84,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry.data.get(CONF_VERIFY_SSL, True),
         )
 
-    # Update device registry immediately after connection with available device IDs
-    # This ensures device metadata (model, firmware, MAC) is visible in UI even if
-    # the first coordinator refresh times out or is deferred
-    # Note: Calling coordinator._update_device_registry is acceptable here as the
-    # integration setup has tight coupling with the coordinator implementation
-    coordinator._update_device_registry(_get_client_device_ids(client))
-
     # Register a push callback if supported by the client
     if hasattr(client, "set_status_callback"):
 
@@ -171,6 +164,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.add_update_listener(_async_options_updated)
 
     await hass.config_entries.async_forward_entry_setups(entry, platforms)
+
+    # Update device registry now that entities (and their device entries) exist
+    # This ensures device metadata (model, firmware, MAC) is visible in UI
+    coordinator._update_device_registry(_get_client_device_ids(client))
 
     # Log connection success with device count at INFO, details at DEBUG
     ids = _get_client_device_ids(client)

--- a/custom_components/fansync/client.py
+++ b/custom_components/fansync/client.py
@@ -23,6 +23,7 @@ from typing import Any
 import httpx
 import websocket
 from homeassistant.core import HomeAssistant
+from websocket import WebSocketTimeoutException
 
 from .const import (
     DEFAULT_WS_TIMEOUT_SECS,
@@ -508,6 +509,10 @@ class FanSyncClient:
 
         try:
             return await self.hass.async_add_executor_job(_get)
+        except WebSocketTimeoutException as exc:
+            # Convert WebSocket timeout to standard TimeoutError for consistent handling
+            self.metrics.record_command(success=False)
+            raise TimeoutError(f"WebSocket recv timed out: {exc}") from exc
         except Exception:
             self.metrics.record_command(success=False)
             raise

--- a/tests/test_client_websocket_timeout.py
+++ b/tests/test_client_websocket_timeout.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Trevor Baker, all rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test WebSocket timeout exception handling in FanSyncClient."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from websocket import WebSocketTimeoutException
+
+from custom_components.fansync.client import FanSyncClient
+
+
+def _login_ok() -> str:
+    return json.dumps({"status": "ok", "response": "login", "id": 1})
+
+
+def _lst_device_ok(device_id: str = "test_device") -> str:
+    return json.dumps(
+        {
+            "status": "ok",
+            "response": "lst_device",
+            "data": [{"device": device_id}],
+            "id": 2,
+        }
+    )
+
+
+async def test_websocket_timeout_converts_to_timeout_error(hass: HomeAssistant) -> None:
+    """Test that WebSocketTimeoutException is converted to TimeoutError.
+
+    This ensures consistent error handling across the codebase and prevents
+    unexpected exceptions from propagating to Home Assistant's websocket API.
+    """
+    client = FanSyncClient(hass, "test@example.com", "password", verify_ssl=True, enable_push=False)
+
+    with (
+        patch("custom_components.fansync.client.httpx.Client") as http_cls,
+        patch("custom_components.fansync.client.websocket.WebSocket") as ws_cls,
+    ):
+        # Setup HTTP mock
+        http_inst = http_cls.return_value
+        http_inst.post.return_value = type(
+            "R",
+            (),
+            {
+                "raise_for_status": lambda self: None,
+                "json": lambda self: {"token": "test_token"},
+            },
+        )()
+
+        # Setup WebSocket mock
+        ws = ws_cls.return_value
+        ws.connect.return_value = None
+        ws.recv.side_effect = [_login_ok(), _lst_device_ok("test_device")]
+
+        try:
+            await client.async_connect()
+
+            # Simulate WebSocketTimeoutException on recv during get_status
+            ws.recv.side_effect = WebSocketTimeoutException("Connection timed out")
+
+            # Verify that WebSocketTimeoutException is converted to TimeoutError
+            with pytest.raises(TimeoutError) as exc_info:
+                await client.async_get_status()
+
+            # Verify the error message includes context
+            assert "WebSocket recv timed out" in str(exc_info.value)
+
+            # Verify metrics recorded the failure
+            assert client.metrics.failed_commands == 1
+            assert client.metrics.total_commands == 1
+
+        finally:
+            await client.async_disconnect()
+
+
+async def test_websocket_timeout_during_recv_in_get_status(hass: HomeAssistant) -> None:
+    """Test WebSocket timeout during recv in get_status is handled gracefully.
+
+    This simulates the real-world scenario where the cloud API is slow and
+    the WebSocket recv operation times out while waiting for a response.
+    """
+    client = FanSyncClient(hass, "test@example.com", "password", verify_ssl=True, enable_push=False)
+
+    with (
+        patch("custom_components.fansync.client.httpx.Client") as http_cls,
+        patch("custom_components.fansync.client.websocket.WebSocket") as ws_cls,
+    ):
+        # Setup HTTP mock
+        http_inst = http_cls.return_value
+        http_inst.post.return_value = type(
+            "R",
+            (),
+            {
+                "raise_for_status": lambda self: None,
+                "json": lambda self: {"token": "test_token"},
+            },
+        )()
+
+        # Setup WebSocket mock
+        ws = ws_cls.return_value
+        ws.connect.return_value = None
+        ws.recv.side_effect = [
+            _login_ok(),
+            _lst_device_ok("test_device"),
+            # First get_status times out
+            WebSocketTimeoutException("Connection timed out"),
+        ]
+
+        try:
+            await client.async_connect()
+
+            # First call should raise TimeoutError (converted from WebSocketTimeoutException)
+            with pytest.raises(TimeoutError):
+                await client.async_get_status()
+
+            # Verify metrics
+            assert client.metrics.failed_commands == 1
+            assert client.metrics.total_commands == 1
+
+        finally:
+            await client.async_disconnect()
+
+
+async def test_other_exceptions_still_propagate(hass: HomeAssistant) -> None:
+    """Test that non-timeout exceptions still propagate normally.
+
+    This ensures we're not catching too broadly and only handling
+    WebSocketTimeoutException specifically.
+    """
+    client = FanSyncClient(hass, "test@example.com", "password", verify_ssl=True, enable_push=False)
+
+    with (
+        patch("custom_components.fansync.client.httpx.Client") as http_cls,
+        patch("custom_components.fansync.client.websocket.WebSocket") as ws_cls,
+    ):
+        # Setup HTTP mock
+        http_inst = http_cls.return_value
+        http_inst.post.return_value = type(
+            "R",
+            (),
+            {
+                "raise_for_status": lambda self: None,
+                "json": lambda self: {"token": "test_token"},
+            },
+        )()
+
+        # Setup WebSocket mock
+        ws = ws_cls.return_value
+        ws.connect.return_value = None
+        ws.recv.side_effect = [
+            _login_ok(),
+            _lst_device_ok("test_device"),
+            # Simulate a different exception (not timeout)
+            RuntimeError("Connection closed unexpectedly"),
+        ]
+
+        try:
+            await client.async_connect()
+
+            # RuntimeError should propagate as-is
+            with pytest.raises(RuntimeError, match="Connection closed unexpectedly"):
+                await client.async_get_status()
+
+            # Verify metrics
+            assert client.metrics.failed_commands == 1
+
+        finally:
+            await client.async_disconnect()


### PR DESCRIPTION
Fixes two critical issues impacting user experience when the FanSync cloud API experiences high latency (30-90+ seconds):

1. WebSocketTimeoutException propagating to Home Assistant UI
2. Device metadata (model, firmware, MAC) not appearing in UI

Root Causes:
- websocket-client library raises WebSocketTimeoutException during slow recv() operations, which was not caught and propagated to HA's websocket API handler, showing "Unexpected exception" errors to users
- Previous fix in PR #99 called _update_device_registry() before device entries existed in registry, causing silent failure and skipped updates

Changes:
- Import and catch WebSocketTimeoutException in async_get_status, convert to standard TimeoutError for consistent error handling across codebase
- Move _update_device_registry() call to AFTER platform setup completes, ensuring device entries exist before attempting to update metadata
- Add comprehensive tests for timeout exception conversion

Testing:
- test_websocket_timeout_converts_to_timeout_error: Verifies conversion
- test_websocket_timeout_during_recv_in_get_status: Simulates slow cloud
- test_other_exceptions_still_propagate: Ensures narrow exception handling

All 117 tests pass. These fixes complement existing optimistic updates and slow connection warnings, ensuring graceful degradation and correct device metadata display even during severe cloud API delays.

Fixes traceback observed in user logs where fan control commands triggered WebSocketTimeoutException during confirmation retries. Also fixes issue where device metadata was visible in diagnostics but not in UI.