### PR TITLE
fix: route push updates to originating device in multi-fan setups

### DIFF
--- a/custom_components/fansync/__init__.py
+++ b/custom_components/fansync/__init__.py
@@ -135,9 +135,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: FanSyncConfigEntry) -> b
         # Register a push callback if supported by the client
         if hasattr(client, "set_status_callback"):
 
-            def _on_status(status: dict[str, object]) -> None:
-                # Merge pushed status for this device into the coordinator's mapping
-                did = getattr(client, "device_id", None) or "unknown"
+            def _on_status(device_id: str, status: dict[str, object]) -> None:
+                # Merge pushed status for this device into the coordinator's mapping.
+                # device_id identifies the originating device so multi-device setups
+                # do not cross-contaminate each other's state.
+                did = device_id or getattr(client, "device_id", None) or "unknown"
                 current = coordinator.data or {}
                 merged: dict[str, dict[str, object]] = dict(current)
                 merged[did] = status

--- a/custom_components/fansync/client.py
+++ b/custom_components/fansync/client.py
@@ -91,7 +91,7 @@ class FanSyncClient:
         self._device_ids: list[str] = []
         self._device_meta: dict[str, dict[str, Any]] = {}
         self._device_profile: dict[str, dict[str, Any]] = {}
-        self._status_callback: Callable[[dict[str, Any]], None] | None = None
+        self._status_callback: Callable[[str, dict[str, Any]], None] | None = None
         self._running: bool = False
         self._recv_task: asyncio.Task | None = None
         self._push_count: int = 0
@@ -692,7 +692,9 @@ class FanSyncClient:
                     if self._status_callback is not None:
                         # Use call_soon since we are in the event loop.
                         # This avoids the overhead of thread-safe locking.
-                        self.hass.loop.call_soon(self._status_callback, pushed_status)
+                        # push_device identifies which device this status belongs to,
+                        # so multi-device setups route the update to the correct entity.
+                        self.hass.loop.call_soon(self._status_callback, push_device, pushed_status)
 
             except TimeoutError:
                 self._last_recv_error = "TimeoutError"
@@ -1093,9 +1095,10 @@ class FanSyncClient:
             if isinstance(ack_data, dict) and isinstance(ack_data.get("status"), dict):
                 if _LOGGER.isEnabledFor(logging.DEBUG):
                     _LOGGER.debug("set ack with status keys=%s", list(ack_data["status"].keys()))
-                # Trigger status callback with the acknowledged status
+                # Trigger status callback with the acknowledged status, routed to the
+                # device that was actually set (not the connection's default device).
                 if self._status_callback is not None:
-                    self.hass.loop.call_soon(self._status_callback, ack_data["status"])
+                    self.hass.loop.call_soon(self._status_callback, did, ack_data["status"])
 
         except Exception as exc:
             self.metrics.record_command(success=False)
@@ -1178,7 +1181,7 @@ class FanSyncClient:
     def device_profile(self, device_id: str) -> dict[str, Any]:
         return dict(self._device_profile.get(device_id, {}))
 
-    def set_status_callback(self, callback: Callable[[dict[str, Any]], None]) -> None:
+    def set_status_callback(self, callback: Callable[[str, dict[str, Any]], None]) -> None:
         self._status_callback = callback
 
     def ws_timeout_seconds(self) -> int:

--- a/tests/test_client_core.py
+++ b/tests/test_client_core.py
@@ -181,7 +181,7 @@ async def test_async_set_triggers_callback(hass: HomeAssistant, mock_websocket) 
 
         # Capture callback result
         seen: list[dict[str, int]] = []
-        c.set_status_callback(lambda s: seen.append(s))
+        c.set_status_callback(lambda d, s: seen.append(s))
 
         await c.async_connect()
         try:
@@ -237,7 +237,7 @@ async def test_async_set_uses_ack_status_when_present(hass: HomeAssistant, mock_
         ws_connect.return_value = mock_websocket
 
         seen: list[dict[str, int]] = []
-        c.set_status_callback(lambda s: seen.append(s))
+        c.set_status_callback(lambda d, s: seen.append(s))
 
         await c.async_connect()
         try:

--- a/tests/test_client_misc.py
+++ b/tests/test_client_misc.py
@@ -156,7 +156,7 @@ async def test_push_ignores_irrelevant_frames(hass: HomeAssistant, mock_websocke
         mock_websocket.recv.side_effect = recv_generator()
         ws_connect.return_value = mock_websocket
 
-        c.set_status_callback(lambda s: seen.append(s))
+        c.set_status_callback(lambda d, s: seen.append(s))
         await c.async_connect()
 
         try:

--- a/tests/test_client_no_duplicate_callbacks.py
+++ b/tests/test_client_no_duplicate_callbacks.py
@@ -86,7 +86,7 @@ async def test_set_ack_with_status_triggers_callback_exactly_once(
         # Track callback invocations with detailed logging
         callback_invocations: list[dict[str, int]] = []
 
-        def track_callback(status: dict[str, int]) -> None:
+        def track_callback(device_id: str, status: dict[str, int]) -> None:
             """Track each callback invocation with the status data."""
             callback_invocations.append(status.copy())
 
@@ -156,7 +156,7 @@ async def test_set_ack_without_status_does_not_trigger_callback(
         ws_connect.return_value = mock_websocket
 
         callback_invocations: list[dict[str, int]] = []
-        client.set_status_callback(lambda s: callback_invocations.append(s))
+        client.set_status_callback(lambda d, s: callback_invocations.append(s))
 
         try:
             await client.async_connect()

--- a/tests/test_client_push_ack.py
+++ b/tests/test_client_push_ack.py
@@ -70,7 +70,7 @@ async def test_set_ack_status_immediate_push(hass: HomeAssistant, mock_websocket
         ws_connect.return_value = mock_websocket
 
         seen: list[dict[str, int]] = []
-        c.set_status_callback(lambda s: seen.append(s))
+        c.set_status_callback(lambda d, s: seen.append(s))
 
         await c.async_connect()
         try:

--- a/tests/test_client_reconnect_and_ack.py
+++ b/tests/test_client_reconnect_and_ack.py
@@ -80,7 +80,7 @@ async def test_set_uses_ack_status_when_present(hass: HomeAssistant, mock_websoc
         ws_connect.return_value = mock_websocket
 
         seen: list[dict[str, int]] = []
-        c.set_status_callback(lambda s: seen.append(s))
+        c.set_status_callback(lambda d, s: seen.append(s))
 
         await c.async_connect()
         try:

--- a/tests/test_client_reconnect_closed.py
+++ b/tests/test_client_reconnect_closed.py
@@ -182,7 +182,7 @@ async def test_set_reconnects_on_closed_socket(hass: HomeAssistant, mock_websock
             # We need to capture the callback to verify the status update from the set response
             callback_status = {}
 
-            def on_status(s) -> None:
+            def on_status(device_id, s) -> None:
                 callback_status.update(s)
 
             c.set_status_callback(on_status)

--- a/tests/test_client_recv_loop.py
+++ b/tests/test_client_recv_loop.py
@@ -63,7 +63,7 @@ async def test_client_push_loop_invokes_callback(hass: HomeAssistant):
 
         ws.recv.side_effect = recv_generator()
 
-        c.set_status_callback(lambda s: seen.append(s))
+        c.set_status_callback(lambda d, s: seen.append(s))
         await c.async_connect()
 
         try:

--- a/tests/test_client_recv_reconnect.py
+++ b/tests/test_client_recv_reconnect.py
@@ -80,7 +80,7 @@ async def test_recv_loop_reconnects_after_timeouts(hass: HomeAssistant, mock_web
         ws_connect.return_value = mock_websocket
 
         seen: list[dict[str, int]] = []
-        c.set_status_callback(lambda s: seen.append(s))
+        c.set_status_callback(lambda d, s: seen.append(s))
 
         # Wrap ensure_ws to observe reconnect calls
         with patch.object(c, "_ensure_ws_connected", wraps=c._ensure_ws_connected) as ensure_wrap:
@@ -123,7 +123,7 @@ async def test_recv_loop_handles_device_change_push(hass: HomeAssistant, mock_we
         ws_connect.return_value = mock_websocket
 
         seen: list[dict[str, int]] = []
-        client.set_status_callback(lambda s: seen.append(s))
+        client.set_status_callback(lambda d, s: seen.append(s))
 
         await client.async_connect()
 

--- a/tests/test_fan_light_optimistic_branches.py
+++ b/tests/test_fan_light_optimistic_branches.py
@@ -39,7 +39,7 @@ class BranchClient:
         # Immediate confirmation path
         self.status.update(data)
         if self._cb:
-            self._cb(dict(self.status))
+            self._cb(self.device_id, dict(self.status))
 
     def set_status_callback(self, cb):
         self._cb = cb

--- a/tests/test_fan_light_success_paths.py
+++ b/tests/test_fan_light_success_paths.py
@@ -37,7 +37,7 @@ class SimpleClient:
     async def async_set(self, data: dict[str, int], *, device_id: str | None = None):
         self.status.update(data)
         if self._cb:
-            self._cb(dict(self.status))
+            self._cb(self.device_id, dict(self.status))
 
     def set_status_callback(self, cb):
         self._cb = cb

--- a/tests/test_integration_setup.py
+++ b/tests/test_integration_setup.py
@@ -45,7 +45,7 @@ class ClientWithCallback:
     async def async_set(self, data: dict[str, int], *, device_id: str | None = None) -> None:
         self.status.update(data)
 
-    def set_status_callback(self, cb: Callable[[dict[str, object]], None]) -> None:
+    def set_status_callback(self, cb: Callable[[str, dict[str, object]], None]) -> None:
         self._cb = cb
 
 
@@ -117,7 +117,7 @@ async def test_setup_registers_callback_and_unload_disconnects(hass: HomeAssista
     assert client._cb is not None
 
     # Trigger push status
-    client._cb({"H00": 1, "H02": 55, "H06": 0, "H01": 0})  # type: ignore[misc]
+    client._cb(client.device_id, {"H00": 1, "H02": 55, "H06": 0, "H01": 0})  # type: ignore[misc]
     await hass.async_block_till_done()
     state = hass.states.get("fan.fansync_fan")
     assert state.attributes.get("percentage") == 55

--- a/tests/test_multi_device.py
+++ b/tests/test_multi_device.py
@@ -129,6 +129,39 @@ async def test_multi_device_control_isolated(hass: HomeAssistant):
     assert hass.states.get(dev2_eid).attributes.get("percentage") == 30
 
 
+async def test_multi_device_push_routed_to_correct_device(hass: HomeAssistant):
+    """A push for one device must not overwrite another device's state.
+
+    Regression for GH #185 / #188: pushes (and set acks) were attributed to the
+    connection's default device (device_ids[0]), so controlling a non-first fan
+    updated the first fan's displayed state.
+    """
+    client = MultiDeviceClient()
+    await setup_entry_with_client(hass, client)
+
+    registry = er.async_get(hass)
+    by_device: dict[str, str] = {}
+    for e in registry.entities.values():
+        if e.platform == "fansync" and e.domain == "fan":
+            if e.unique_id and e.unique_id.startswith("fansync_") and e.unique_id.endswith("_fan"):
+                by_device[e.unique_id[len("fansync_") : -len("_fan")]] = e.entity_id
+
+    dev1_eid = by_device["dev1"]
+    dev2_eid = by_device["dev2"]
+
+    assert hass.states.get(dev1_eid).attributes.get("percentage") == 20
+    assert hass.states.get(dev2_eid).attributes.get("percentage") == 30
+
+    # Simulate a push update originating from dev2 (e.g. set ack or cloud push).
+    assert client._cb is not None
+    client._cb("dev2", {"H00": 1, "H02": 88, "H06": 0, "H01": 0})
+    await hass.async_block_till_done()
+
+    # dev2 reflects the push; dev1 must be untouched.
+    assert hass.states.get(dev2_eid).attributes.get("percentage") == 88
+    assert hass.states.get(dev1_eid).attributes.get("percentage") == 20
+
+
 class SingleDeviceListClient:
     """Client that exposes empty device_ids to exercise fallback single-device path."""
 

--- a/tests/test_overlay_behavior.py
+++ b/tests/test_overlay_behavior.py
@@ -40,7 +40,7 @@ class OverlayClient:
         # Simulate delayed confirmation by invoking callback after a small delay
         self.status.update(data)
         if self._cb:
-            self._cb(dict(self.status))
+            self._cb(self.device_id, dict(self.status))
 
     def set_status_callback(self, cb):
         self._cb = cb

--- a/tests/test_snapback_behavior.py
+++ b/tests/test_snapback_behavior.py
@@ -93,7 +93,7 @@ async def test_fan_snapback_after_guard_expiry(hass: HomeAssistant):
         # Advance time beyond guard window, then push old backend state (20%)
         fake_monotonic.t = base + OPTIMISTIC_GUARD_SEC + 1.0  # type: ignore[attr-defined]
         if client._cb:
-            client._cb({"H00": 1, "H02": 20, "H06": 0, "H01": 0})
+            client._cb(client.device_id, {"H00": 1, "H02": 20, "H06": 0, "H01": 0})
         await hass.async_block_till_done()
 
         # After guard expiry and a non-confirming update, UI should reflect backend (snap-back)
@@ -127,7 +127,7 @@ async def test_light_snapback_after_guard_expiry(hass: HomeAssistant):
         # Advance beyond guard window and push old brightness (20%)
         fake_monotonic.t = base + OPTIMISTIC_GUARD_SEC + 1.0  # type: ignore[attr-defined]
         if client._cb:
-            client._cb({"H0B": 1, "H0C": 20})
+            client._cb(client.device_id, {"H0B": 1, "H0C": 20})
         await hass.async_block_till_done()
 
         state = hass.states.get("light.fansync_light")


### PR DESCRIPTION
## Summary

Fixes #185 and #188 — both report the same defect: on a multi-fan account, controlling one fan changes another fan's displayed state.

## Root cause

The status callback never carried a device identity. Every WebSocket push update and every `set` acknowledgment was attributed to `client.device_id`, which is always `device_ids[0]` — the **first** device.

- `client.py` already extracted the originating `push_device` from each push frame, then discarded it, invoking the callback with only the status dict.
- `async_set` fired its ack callback with just the status, no device id.
- `__init__.py`'s `_on_status` merged that status into the coordinator under the first device's slot.

So any push/ack for fan 2 or 3 overwrote fan 1's state. This explains #185 (controlling fan 2/3 makes fan 1 mirror them) and #188's asymmetry: controlling fan A (`device_ids[0]`) routes correctly, but controlling fan B is misattributed to A. #188's own diagnostics confirm it — both devices report byte-identical state at every timestamp.

The existing `test_multi_device` only exercised the **polling** path (which fetches per-device correctly), so the push/ack path bug went uncaught.

## Fix

Thread the device id through the callback; the contract becomes `callback(device_id, status)`:

- Push path passes the extracted `push_device`.
- Set-ack path passes the device that was actually set.
- `_on_status` routes the merge to that device, falling back to the connection default only when empty.

## Tests

- Added `test_multi_device_push_routed_to_correct_device`, reproducing the exact scenario (a push for dev2 must not change dev1). Verified it fails without the fix and passes with it.
- Updated existing callback call sites/mocks to the two-arg contract.
- Full suite: 185 passed, 4 skipped. `make lint format-check type-check` all clean.