### PR TITLE
chore(deps-dev): bump homeassistant and pytest for security alerts

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,12 +12,12 @@
 
 # Development requirements for CI and local checks
 black==26.3.1
-homeassistant==2026.4.3
+homeassistant==2026.6.4
 mypy==1.20.2
 pycares==5.0.1
-pytest-cov==7.0.0
-pytest-homeassistant-custom-component==0.13.324
-pytest==9.0.0
+pytest-cov==7.1.0
+pytest-homeassistant-custom-component==0.13.340
+pytest==9.0.3
 pre-commit==4.5.1
 ruff==0.15.11
 # Runtime deps required by integration (for local tests)

--- a/tests/test_early_device_registry.py
+++ b/tests/test_early_device_registry.py
@@ -146,6 +146,11 @@ async def test_early_registry_handles_exception_gracefully(hass: HomeAssistant) 
 
     mock_client.async_connect = mock_connect
 
+    async def mock_disconnect() -> None:
+        pass
+
+    mock_client.async_disconnect = mock_disconnect
+
     async def mock_get_status(device_id: str | None = None) -> dict[str, int]:
         return {"power": 1, "speed": 3}
 

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -108,6 +108,7 @@ async def test_options_flow_sets_timeouts_and_setup_uses_them(hass):
     with patch("custom_components.fansync.FanSyncClient") as client_cls:
         client = client_cls.return_value
         client.async_connect = AsyncMock(return_value=None)
+        client.async_disconnect = AsyncMock(return_value=None)
         client.set_status_callback = lambda cb: None
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()


### PR DESCRIPTION
## Summary

Resolves both open Dependabot security alerts, which are in the dev/test toolchain (`requirements-dev.txt`) — neither ships to users.

| Alert | Package | From → To | Severity |
|---|---|---|---|
| [GHSA-x84v-g949-293w](https://github.com/advisories/GHSA-x84v-g949-293w) | homeassistant | `2026.4.3` → `2026.6.4` | High |
| [GHSA-6w46-j5rx-g56g](https://github.com/advisories/GHSA-6w46-j5rx-g56g) | pytest | `9.0.0` → `9.0.3` | Medium |

`pytest-homeassistant-custom-component` pins exact versions of both `homeassistant` and `pytest`, so it's bumped to `0.13.340` — the release that pins HA `2026.6.4` + pytest `9.0.3`. That in turn requires `pytest-cov 7.1.0`, also bumped.

## Test changes

HA 2026.6.x unloads config entries during test teardown, which now awaits `client.async_disconnect()`. Two mock clients (`test_timeouts.py`, `test_early_device_registry.py`) only had a plain `MagicMock` for that method; they now provide an awaitable `async_disconnect` so teardown succeeds.

## Verification

`make check` clean: **184 passed, 4 skipped**, ruff + black + mypy all pass, coverage 89%.

No runtime/integration code changed — the integration's HA minimum (`2026.3.0`) is unaffected.