### PR TITLE
fix: harden websocket reconnect, auth refresh, and status handling

### DIFF
--- a/custom_components/fansync/client.py
+++ b/custom_components/fansync/client.py
@@ -40,6 +40,10 @@ from .const import (
     WS_GREETING_TIMEOUT_SEC,
     WS_LOGIN_RETRY_ATTEMPTS,
     WS_LOGIN_RETRY_BACKOFF_SEC,
+    WS_RECV_BACKOFF_INITIAL_SEC,
+    WS_RECV_BACKOFF_MAX_SEC,
+    WS_RECV_SLEEP_SEC,
+    WS_RECV_TIMEOUT_ERROR_THRESHOLD,
     WS_REQUEST_ID_LIST_DEVICES,
     WS_REQUEST_ID_LOGIN,
 )
@@ -116,6 +120,9 @@ class FanSyncClient:
         # async_get_status and async_set which rely on _pending_requests routing.
         self._next_request_id: int = 3
         self._request_id_lock = asyncio.Lock()
+        # Serializes reconnects so a background recv-loop reconnect and a
+        # command-path reconnect cannot race and orphan each other's socket.
+        self._reconnect_lock = asyncio.Lock()
         self.metrics = ConnectionMetrics()
         # Diagnostics tracking
         self._last_http_login_ms: float | None = None
@@ -610,13 +617,13 @@ class FanSyncClient:
     async def _recv_loop(self) -> None:
         """Background task to receive push updates from WebSocket."""
         timeout_errors = 0
-        backoff_sec = 0.5
-        max_backoff_sec = 5.0
+        backoff_sec = WS_RECV_BACKOFF_INITIAL_SEC
+        max_backoff_sec = WS_RECV_BACKOFF_MAX_SEC
 
         while self._running:
             ws = self._ws
             if ws is None:
-                await asyncio.sleep(0.1)
+                await asyncio.sleep(WS_RECV_SLEEP_SEC)
                 continue
 
             try:
@@ -627,7 +634,7 @@ class FanSyncClient:
                 )
                 raw = await asyncio.wait_for(ws.recv(), timeout=ws_timeout)
                 timeout_errors = 0
-                backoff_sec = 0.5
+                backoff_sec = WS_RECV_BACKOFF_INITIAL_SEC
 
                 # Process message
                 try:
@@ -707,7 +714,7 @@ class FanSyncClient:
                         ws_timeout,
                     )
                 timeout_errors += 1
-                if timeout_errors >= 3:
+                if timeout_errors >= WS_RECV_TIMEOUT_ERROR_THRESHOLD:
                     # Reconnect after consecutive timeouts
                     if _LOGGER.isEnabledFor(logging.DEBUG):
                         _LOGGER.debug(
@@ -718,7 +725,7 @@ class FanSyncClient:
                     try:
                         await self._ensure_ws_connected()
                         timeout_errors = 0
-                        backoff_sec = 0.5
+                        backoff_sec = WS_RECV_BACKOFF_INITIAL_SEC
                         self.metrics.record_reconnect()
                         self._last_reconnect_utc = datetime.now(UTC).isoformat()
                         if _LOGGER.isEnabledFor(logging.DEBUG):
@@ -735,18 +742,19 @@ class FanSyncClient:
                         backoff_sec = min(max_backoff_sec, backoff_sec * 2)
                 else:
                     # Brief sleep before retry
-                    await asyncio.sleep(0.1)
+                    await asyncio.sleep(WS_RECV_SLEEP_SEC)
 
             except Exception as err:
                 self._last_recv_error = type(err).__name__
                 self._last_recv_error_utc = datetime.now(UTC).isoformat()
+                self.metrics.record_websocket_error()
                 if _LOGGER.isEnabledFor(logging.DEBUG):
                     _LOGGER.debug("recv error=%s err=%s", type(err).__name__, err)
                 # Connection closed, trigger reconnect
                 try:
                     await self._ensure_ws_connected()
                     timeout_errors = 0
-                    backoff_sec = 0.5
+                    backoff_sec = WS_RECV_BACKOFF_INITIAL_SEC
                     self.metrics.record_reconnect()
                     self._last_reconnect_utc = datetime.now(UTC).isoformat()
                 except Exception as reconnect_err:
@@ -765,12 +773,25 @@ class FanSyncClient:
             _LOGGER.debug("_recv_loop exited (client disconnected)")
 
     async def _ensure_ws_connected(self) -> None:
-        """Ensure WebSocket is connected and authenticated."""
-        reconnect_start = time.monotonic()
-        # If WebSocket is already connected and open, nothing to do
+        """Ensure the WebSocket is connected, serializing concurrent reconnects.
+
+        The fast path (already OPEN) returns without taking the lock. Otherwise a
+        single reconnect runs under ``_reconnect_lock`` so that a background
+        recv-loop reconnect and a command-path reconnect cannot build two sockets
+        and orphan one of them.
+        """
         if self._ws is not None and self._ws.state == State.OPEN:
             return
+        async with self._reconnect_lock:
+            # Re-check under the lock: another caller may have completed the
+            # reconnect while we were waiting to acquire it.
+            if self._ws is not None and self._ws.state == State.OPEN:
+                return
+            await self._reconnect()
 
+    async def _reconnect(self) -> None:
+        """Reconnect and re-authenticate the WebSocket. Caller holds the lock."""
+        reconnect_start = time.monotonic()
         # Close old WebSocket if it exists
         if self._ws is not None:
             try:
@@ -844,6 +865,12 @@ class FanSyncClient:
         raw = await asyncio.wait_for(ws.recv(), timeout=ws_timeout)
         payload = json.loads(raw)
         if not (isinstance(payload, dict) and payload.get("status") == "ok"):
+            # The token is likely expired or invalid. Drop it so the next
+            # reconnect re-authenticates via HTTP login (which yields a fresh
+            # token, or surfaces a 401 that the coordinator maps to reauth).
+            # Without this, _token is never cleared and the refresh branch above
+            # is dead — a reconnect after token expiry would loop forever.
+            self._token = None
             raise RuntimeError("WebSocket login failed")
 
         self._ws = ws
@@ -997,10 +1024,21 @@ class FanSyncClient:
                     did,
                 )
 
-            return payload["data"]["status"]
+            # Validate the response shape instead of indexing blindly: a malformed
+            # or offline-device reply (no data.status dict) would otherwise raise
+            # KeyError and, in a multi-device poll, fail the whole coordinator
+            # refresh and drop every entity to unavailable.
+            result_data = payload.get("data")
+            status = result_data.get("status") if isinstance(result_data, dict) else None
+            if not isinstance(status, dict):
+                raise RuntimeError(
+                    f"Unexpected get response for {did}: missing status payload "
+                    f"(response status={payload.get('status')!r})"
+                )
+            return status
 
         except TimeoutError as exc:
-            self.metrics.record_command(success=False)
+            self.metrics.record_timeout()
             self._record_command_history(
                 command="get",
                 device_id=did,
@@ -1101,7 +1139,10 @@ class FanSyncClient:
                     self.hass.loop.call_soon(self._status_callback, did, ack_data["status"])
 
         except Exception as exc:
-            self.metrics.record_command(success=False)
+            if isinstance(exc, TimeoutError):
+                self.metrics.record_timeout()
+            else:
+                self.metrics.record_command(success=False)
             self._record_command_history(
                 command="set",
                 device_id=did,

--- a/custom_components/fansync/config_flow.py
+++ b/custom_components/fansync/config_flow.py
@@ -66,8 +66,10 @@ class FanSyncConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is None:
             return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)
 
-        # Set unique ID early to avoid unnecessary network calls on duplicates
-        await self.async_set_unique_id(user_input[CONF_EMAIL])
+        # Set unique ID early to avoid unnecessary network calls on duplicates.
+        # Normalize the email so "User@x.com" and "user@x.com" collapse to one
+        # entry instead of slipping past the duplicate guard.
+        await self.async_set_unique_id(user_input[CONF_EMAIL].strip().lower())
         self._abort_if_unique_id_configured()
 
         errors = {}

--- a/custom_components/fansync/const.py
+++ b/custom_components/fansync/const.py
@@ -65,12 +65,11 @@ MAX_WS_TIMEOUT_SECS = 120
 WS_LOGIN_RETRY_ATTEMPTS = 2
 WS_LOGIN_RETRY_BACKOFF_SEC = 1.0
 
-# WebSocket receive loop retry settings
+# WebSocket receive loop retry settings (consumed by client._recv_loop)
 WS_RECV_TIMEOUT_ERROR_THRESHOLD = 3  # Consecutive errors before reconnect
 WS_RECV_BACKOFF_INITIAL_SEC = 0.5  # Initial backoff delay
 WS_RECV_BACKOFF_MAX_SEC = 5.0  # Maximum backoff delay
 WS_RECV_SLEEP_SEC = 0.1  # Sleep between recv attempts
-WS_RECV_LOCK_TIMEOUT_SEC = 0.5  # Timeout for recv_lock acquisition in background loop
 
 # Push update logging (tune higher for quieter logs)
 PUSH_LOG_EVERY = 50
@@ -84,9 +83,6 @@ MISMATCH_HISTORY_MAX = 10
 # GET_STATUS and SET now use dynamic allocation via _next_request_id
 WS_REQUEST_ID_LOGIN = 1
 WS_REQUEST_ID_LIST_DEVICES = 2
-
-# WebSocket bounded read settings
-WS_GET_RETRY_LIMIT = 5  # Max recv attempts to find get response
 
 # WebSocket fallback timeout (used when _ws_timeout_s is None)
 WS_FALLBACK_TIMEOUT_SEC = 10.0

--- a/custom_components/fansync/coordinator.py
+++ b/custom_components/fansync/coordinator.py
@@ -251,6 +251,22 @@ class FanSyncCoordinator(DataUpdateCoordinator[dict[str, dict[str, object]]]):
                     )
                     timeout_devices.append(did)
                     return did, None
+                except httpx.HTTPStatusError:
+                    # Auth/HTTP failures (e.g. 401/403 during token refresh) must
+                    # reach the outer handler so it can trigger the reauth flow.
+                    raise
+                except Exception as err:
+                    # Tolerate a single device's failure (malformed/offline reply,
+                    # transient connection error) without failing the whole refresh
+                    # and dropping every entity — including healthy ones — to
+                    # unavailable. Keep this device's last known state.
+                    self.logger.warning(
+                        "Status fetch failed for device %s (%s); keeping last known state",
+                        did,
+                        type(err).__name__,
+                    )
+                    timeout_devices.append(did)
+                    return did, None
 
             results = await asyncio.gather(*(_get(d) for d in ids))
             for did, status in results:

--- a/tests/test_auth_hardening.py
+++ b/tests/test_auth_hardening.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Trevor Baker, all rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for WebSocket/auth hardening.
+
+Covers: token refresh on reconnect after auth failure, serialized reconnects,
+malformed get-response validation, and config-flow email normalization.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant import data_entry_flow
+from homeassistant.core import HomeAssistant
+from websockets.protocol import State
+
+from custom_components.fansync.client import FanSyncClient
+
+
+def _mock_ws(state: State = State.OPEN, recv_response: str | None = None) -> MagicMock:
+    ws = MagicMock()
+    ws.send = AsyncMock()
+    ws.close = AsyncMock()
+    ws.state = state
+    ws.recv = AsyncMock(return_value=recv_response) if recv_response else AsyncMock()
+    return ws
+
+
+@pytest.mark.asyncio
+async def test_reconnect_clears_token_on_login_failure(hass: HomeAssistant) -> None:
+    """A failed WS login must drop the token so the next reconnect re-authenticates.
+
+    Without clearing it, ``_token`` stays truthy forever, the refresh branch is
+    dead, and a reconnect after token expiry loops indefinitely.
+    """
+    client = FanSyncClient(hass, "e@x.com", "p")
+    client._ws = _mock_ws(state=State.CLOSED)
+    client._token = "expired-token"
+    client._http = MagicMock()
+    import ssl
+
+    client._ssl_context = ssl.create_default_context()
+
+    # New socket whose login response is NOT ok.
+    new_ws = _mock_ws(recv_response='{"status": "error", "response": "login"}')
+
+    with patch(
+        "custom_components.fansync.client.websockets.connect", new_callable=AsyncMock
+    ) as ws_connect:
+        ws_connect.return_value = new_ws
+        with pytest.raises(RuntimeError, match="login failed"):
+            await client._ensure_ws_connected()
+
+    # Token cleared → next _ensure_ws_connected() will HTTP-refresh it.
+    assert client._token is None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_reconnects_run_once(hass: HomeAssistant) -> None:
+    """Two concurrent reconnects must serialize and perform a single reconnect."""
+    client = FanSyncClient(hass, "e@x.com", "p")
+    client._ws = None
+    calls = {"n": 0}
+    open_ws = _mock_ws(state=State.OPEN)
+
+    async def fake_reconnect() -> None:
+        calls["n"] += 1
+        await asyncio.sleep(0)  # let the other coroutine reach the lock
+        client._ws = open_ws
+
+    client._reconnect = fake_reconnect  # type: ignore[method-assign]
+
+    await asyncio.gather(client._ensure_ws_connected(), client._ensure_ws_connected())
+
+    # Second caller re-checks under the lock, sees an OPEN socket, and skips.
+    assert calls["n"] == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"status": "error", "id": 5},  # not ok, no data
+        {"status": "ok", "id": 5},  # ok but no data
+        {"status": "ok", "id": 5, "data": {}},  # ok, data but no status
+        {"status": "ok", "id": 5, "data": {"status": "oops"}},  # status not a dict
+    ],
+)
+async def test_get_status_rejects_malformed_response(hass: HomeAssistant, payload: dict) -> None:
+    """A malformed/offline get-response raises a clean error, never KeyError."""
+    client = FanSyncClient(hass, "e@x.com", "p")
+    client._device_id = "dev1"
+    client._send_request = AsyncMock(return_value=(payload, 5))  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="Unexpected get response"):
+        await client.async_get_status("dev1")
+
+
+@pytest.mark.asyncio
+async def test_get_status_returns_status_on_valid_response(hass: HomeAssistant) -> None:
+    """A well-formed response still returns the status mapping."""
+    client = FanSyncClient(hass, "e@x.com", "p")
+    client._device_id = "dev1"
+    good = {"status": "ok", "id": 5, "data": {"status": {"H00": 1, "H02": 40}}}
+    client._send_request = AsyncMock(return_value=(good, 5))  # type: ignore[method-assign]
+
+    assert await client.async_get_status("dev1") == {"H00": 1, "H02": 40}
+
+
+async def test_config_flow_normalizes_email_unique_id(
+    hass: HomeAssistant, ensure_fansync_importable
+) -> None:
+    """Mixed-case/whitespace emails collapse to one normalized unique_id."""
+    with (
+        patch("custom_components.fansync.config_flow.FanSyncClient") as client_cls,
+        patch("custom_components.fansync.FanSyncClient") as mock_setup,
+    ):
+        instance = client_cls.return_value
+        instance.async_connect = AsyncMock(return_value=None)
+        instance.async_disconnect = AsyncMock(return_value=None)
+        instance.device_ids = ["dev"]
+        mock_setup.return_value.async_connect = AsyncMock(side_effect=RuntimeError("no setup"))
+
+        result = await hass.config_entries.flow.async_init(
+            "fansync",
+            context={"source": "user"},
+            data={"email": "  User@Example.COM ", "password": "p", "verify_ssl": True},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    entries = hass.config_entries.async_entries("fansync")
+    assert len(entries) == 1
+    assert entries[0].unique_id == "user@example.com"


### PR DESCRIPTION
## Summary

Fixes a set of latent connection-layer bugs found during the pre-release review.

### Auth token never refreshed on reconnect (high)
`self._token` was assigned on first connect and **never reset**, so the reconnect refresh branch (`if not self._token`) was dead. After the ~30-day JWT expired, a WebSocket drop → reconnect reused the stale token → `RuntimeError("WebSocket login failed")` → the recv loop retried **forever**, and because it's a `RuntimeError` (not HTTP 401) the reauth flow never fired. Now the token is cleared on WS-login failure, so the next reconnect re-authenticates via HTTP login (yielding a fresh token, or a 401 the coordinator maps to reauth).

### Concurrent reconnect race (med)
`_ensure_ws_connected` had no mutual exclusion; a background recv-loop reconnect and a command-path reconnect could build two sockets and orphan one (also spuriously timing out the in-flight command). Reconnects are now serialized behind `_reconnect_lock` with a double-checked fast path.

### Unvalidated get-status response (med)
`async_get_status` returned `payload["data"]["status"]` unchecked. A malformed/offline-device reply raised `KeyError`, which escaped the coordinator's `TimeoutError`-only catch and (with `gather` and no `return_exceptions`) failed the **whole** multi-device poll — dropping every entity, even healthy ones, to unavailable. Now the response shape is validated, and the coordinator tolerates a single device's failure (keeping its last-known state) while still letting auth (401/403) errors propagate to reauth.

### unique_id not normalized (low)
`async_set_unique_id` used the raw email, so `User@x.com` and `user@x.com` were treated as distinct entries, bypassing the duplicate guard. Now normalized with `.strip().lower()`.

### Cleanup
Wires the previously-dead timeout / websocket-error connection metrics (so `timeout_rate` and the related diagnostics are no longer permanently zero), replaces magic numbers in the recv loop with the existing `WS_RECV_*` constants (removing two genuinely unused ones), and parenthesizes a multi-except clause.

## Tests
Adds `tests/test_auth_hardening.py` (8 cases): token clearing on login failure, serialized concurrent reconnects, malformed-response rejection (parametrized) + valid-response pass-through, and unique_id normalization.

Full suite green: **193 passed, 4 skipped**; ruff/black/mypy clean.