### PR TITLE
fix: ignore pushes for unknown device ids; refactor coordinator poll-commit

### DIFF
--- a/custom_components/fansync/client.py
+++ b/custom_components/fansync/client.py
@@ -676,6 +676,15 @@ class FanSyncClient:
                 if pushed_status is not None:
                     if not push_device:
                         push_device = self._device_id or "unknown"
+                    # push_device is server-controlled. Ignore pushes for devices we
+                    # don't know about: without this, a misbehaving or compromised
+                    # cloud endpoint could grow coordinator.data and the diagnostics
+                    # dicts unboundedly with junk device ids. Unknown ids are inert
+                    # (no entity reads them) so dropping them is safe.
+                    if self._device_ids and push_device not in self._device_ids:
+                        if _LOGGER.isEnabledFor(logging.DEBUG):
+                            _LOGGER.debug("recv push for unknown device=%s; ignoring", push_device)
+                        continue
                     self.metrics.record_push_update()
                     self._push_count += 1
                     self._last_push_monotonic = time.monotonic()

--- a/custom_components/fansync/coordinator.py
+++ b/custom_components/fansync/coordinator.py
@@ -212,26 +212,16 @@ class FanSyncCoordinator(DataUpdateCoordinator[dict[str, dict[str, object]]]):
                     )
                     return self.data or {}
                 # Debug: log mismatches vs current coordinator snapshot
-                current = self.data or {}
-                prev = current.get(did, {}) if isinstance(current, dict) else {}
-                if isinstance(prev, dict) and isinstance(s, dict) and prev != s:
-                    changed = _changed_keys(prev, s)
-                    mismatch_keys[did] = changed
-                    if self.logger.isEnabledFor(logging.DEBUG):
-                        self.logger.debug("poll mismatch d=%s changed_keys=%s", did, changed)
+                mismatch_keys = self._compute_mismatch_keys(self.data or {}, statuses)
+                self._log_push_idle_if_needed()
                 if self.logger.isEnabledFor(logging.DEBUG):
                     self.logger.debug("poll sync done devices=%d", len(statuses))
-                self._log_push_idle_if_needed()
-                # Update device registry with any new profile data
-                self._update_device_registry([did])
-                self._append_status_history(statuses)
-                self._finalize_update(
+                self._commit_successful_update(
                     statuses=statuses,
                     timeout_devices=timeout_devices,
                     mismatch_keys=mismatch_keys,
-                    success=True,
+                    device_count=len(statuses),
                 )
-                self._append_mismatch_history(mismatch_keys, len(statuses))
                 return statuses
 
             # Run per-device status in parallel with timeouts; tolerate partial failures
@@ -282,18 +272,7 @@ class FanSyncCoordinator(DataUpdateCoordinator[dict[str, dict[str, object]]]):
                     if isinstance(prev_data, dict):
                         statuses[did] = prev_data
             # Debug: log mismatches for multi-device
-            if isinstance(current, dict):
-                for did, status in statuses.items():
-                    prev = current.get(did, {})
-                    if isinstance(prev, dict) and isinstance(status, dict) and prev != status:
-                        changed = _changed_keys(prev, status)
-                        mismatch_keys[did] = changed
-                        if self.logger.isEnabledFor(logging.DEBUG):
-                            self.logger.debug(
-                                "poll mismatch d=%s changed_keys=%s",
-                                did,
-                                changed,
-                            )
+            mismatch_keys = self._compute_mismatch_keys(current, statuses)
             self._log_push_idle_if_needed()
             if self.logger.isEnabledFor(logging.DEBUG):
                 self.logger.debug("poll sync done devices=%d", len(statuses))
@@ -314,17 +293,12 @@ class FanSyncCoordinator(DataUpdateCoordinator[dict[str, dict[str, object]]]):
                 )
                 self._append_mismatch_history(mismatch_keys, len(ids))
                 return self.data or {}
-            # Update device registry with any new profile data for all devices
-            self._update_device_registry(list(statuses.keys()))
-            self._append_status_history(statuses)
-            self._finalize_update(
+            self._commit_successful_update(
                 statuses=statuses,
                 timeout_devices=timeout_devices,
                 mismatch_keys=mismatch_keys,
-                success=True,
                 device_count=len(ids),
             )
-            self._append_mismatch_history(mismatch_keys, len(ids))
             return statuses
         except httpx.HTTPStatusError as err:
             # Handle authentication failures by triggering reauth flow
@@ -367,6 +341,41 @@ class FanSyncCoordinator(DataUpdateCoordinator[dict[str, dict[str, object]]]):
         self._last_poll_mismatch_history.append(entry)
         if len(self._last_poll_mismatch_history) > self._last_poll_mismatch_history_max:
             self._last_poll_mismatch_history.pop(0)
+
+    def _compute_mismatch_keys(
+        self, current: object, statuses: dict[str, dict[str, object]]
+    ) -> dict[str, list[str]]:
+        """Return per-device changed keys vs the current coordinator snapshot."""
+        mismatch: dict[str, list[str]] = {}
+        if isinstance(current, dict):
+            for did, status in statuses.items():
+                prev = current.get(did, {})
+                if isinstance(prev, dict) and isinstance(status, dict) and prev != status:
+                    changed = _changed_keys(prev, status)
+                    mismatch[did] = changed
+                    if self.logger.isEnabledFor(logging.DEBUG):
+                        self.logger.debug("poll mismatch d=%s changed_keys=%s", did, changed)
+        return mismatch
+
+    def _commit_successful_update(
+        self,
+        *,
+        statuses: dict[str, dict[str, object]],
+        timeout_devices: list[str],
+        mismatch_keys: dict[str, list[str]],
+        device_count: int,
+    ) -> None:
+        """Shared success path: registry refresh, status/mismatch history, finalize."""
+        self._update_device_registry(list(statuses.keys()))
+        self._append_status_history(statuses)
+        self._finalize_update(
+            statuses=statuses,
+            timeout_devices=timeout_devices,
+            mismatch_keys=mismatch_keys,
+            success=True,
+            device_count=device_count,
+        )
+        self._append_mismatch_history(mismatch_keys, device_count)
 
     def _finalize_update(
         self,

--- a/tests/test_push_device_filter.py
+++ b/tests/test_push_device_filter.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Trevor Baker, all rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Push updates for unknown (server-supplied) device ids must be ignored.
+
+Hardening: push_device is server-controlled, so a misbehaving/compromised cloud
+could otherwise grow coordinator.data and the diagnostics dicts unboundedly.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.fansync.client import FanSyncClient
+
+
+def _login_ok() -> str:
+    return json.dumps({"status": "ok", "response": "login", "id": 1})
+
+
+def _lst_device_ok(device_id: str) -> str:
+    return json.dumps(
+        {"status": "ok", "response": "lst_device", "data": [{"device": device_id}], "id": 2}
+    )
+
+
+def _push_for(device: str, status: dict[str, int]) -> str:
+    return json.dumps(
+        {"status": "ok", "response": "evt", "device": device, "data": {"status": status}, "id": 999}
+    )
+
+
+async def test_push_for_unknown_device_is_ignored(hass: HomeAssistant) -> None:
+    seen: list[tuple[str, dict[str, int]]] = []
+
+    c = FanSyncClient(hass, "e@example.com", "p", verify_ssl=True, enable_push=True)
+    with (
+        patch("custom_components.fansync.client.httpx.Client") as http_cls,
+        patch(
+            "custom_components.fansync.client.websockets.connect", new_callable=AsyncMock
+        ) as ws_connect,
+    ):
+        http = http_cls.return_value
+        http.post.return_value.json.return_value = {"token": "t"}
+        http.post.return_value.raise_for_status.return_value = None
+        ws = ws_connect.return_value
+
+        def recv_generator():
+            yield TimeoutError()  # no server greeting
+            yield _login_ok()
+            yield _lst_device_ok("dev")  # known device set = {"dev"}
+            yield _push_for("stranger", {"H02": 99})  # unknown -> must be dropped
+            yield _push_for("dev", {"H02": 44})  # known -> delivered
+            while True:
+                yield TimeoutError("timeout")
+
+        ws.recv.side_effect = recv_generator()
+        c.set_status_callback(lambda d, s: seen.append((d, s)))
+        await c.async_connect()
+        try:
+            for _ in range(5):
+                await hass.async_block_till_done()
+
+            devices = [d for d, _ in seen]
+            assert "stranger" not in devices, "push for unknown device should be dropped"
+            assert ("dev", {"H02": 44}) in seen, "push for known device should be delivered"
+            # Diagnostics dict must not have grown an entry for the unknown id.
+            assert "stranger" not in c._last_push_by_device
+        finally:
+            await c.async_disconnect()


### PR DESCRIPTION
## Summary

Two changes from the pre-release "try harder" pass — a security hardening (`fix:`) and a safe dedup (`refactor:`).

### fix: ignore push updates for unknown device ids
The security review of the 0.7.6 diff flagged a low-severity issue introduced by the multi-device routing fix (#192): `push_device` is **server-controlled** and now keys `coordinator.data` and the diagnostics dicts. A misbehaving or compromised cloud endpoint could emit unboundedly many distinct device-id strings, growing those structures without limit. The recv loop now drops pushes whose device id isn't in the known `device_ids`. Unknown ids are inert (no entity reads them), so dropping is safe. New test: `tests/test_push_device_filter.py`.

### refactor: extract shared poll-commit helpers
`coordinator._async_update_data` duplicated mismatch detection and the success-commit tail across its single- and multi-device branches. Extracted `_compute_mismatch_keys` and `_commit_successful_update`.

**Important:** I deliberately did **not** collapse the two branches into one (as the review suggested) — they have *intentionally different* timeout semantics (single-device returns last-known with `success=False`; multi-device keeps per-device last-known and stays successful). Merging them would silently change behavior. Only the duplicated bookkeeping is shared; semantics are preserved.

### Deliberately skipped
The review also suggested deduping `client._ws_login` and the diagnostics-recording helpers. On inspection those paths have genuinely different needs (initial-connect tracks detailed phase/timing/`_last_login_response` for first-connect troubleshooting; reconnect is intentionally lean and clears the token on failure). A shared helper would trade real diagnostic clarity for ~10 saved lines — net negative — so I left them.

## Verification
`make check` clean: **194 passed, 4 skipped**, ruff/black/mypy all pass.