### PR TITLE
feat: hide light entity on lightless fans; full esh in diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,11 @@ Push-first updates are used by default. A low-frequency fallback poll can be con
 | fallback_poll_seconds  | Poll interval in seconds when push is unavailable (0 disables polling). | 60      |
 | http_timeout_seconds   | HTTP connect/read timeout (seconds)                               | 20      |
 | ws_timeout_seconds     | WebSocket connect/recv timeout (seconds)                          | 30      |
+| disable_light          | Hide the Light entity for a fan that has no physical light (see below). | off     |
 
 Set via: Settings → Devices & Services → FanSync → Configure → Options.
 - Poll interval allowed range: 15–600 seconds (0 disables polling and relies on push)
+- Changing **Fan has no light** reloads the integration so the Light entity appears/disappears immediately.
 - Timeout ranges: 5–120 seconds (HTTP and WebSocket)
 
 ## Reauthentication
@@ -253,6 +255,14 @@ Then restart Home Assistant and reproduce the issue. Check logs in **Settings** 
 - If `avg_latency_ms > 5000`: Increase WebSocket timeout in integration options
 - If `websocket_reconnects > 10`: Check WiFi signal strength and network stability
 - If `timeout_rate > 0.3`: Network latency issues - check router/ISP
+
+#### A Light Entity Appears for a Fan With No Light
+
+**Symptoms**: A `light.*` entity is created (and may show in the Fanimation app too) even though your fan has no physical light. Controlling it does nothing.
+
+**Cause**: Some fans (e.g. certain Kute60 units) advertise a light channel in their cloud status despite having no bulb. The integration creates the Light entity from that reported channel, so it cannot tell a real light from a phantom one.
+
+**Solution**: Turn on **Fan has no light** in Settings → Devices & Services → FanSync → Configure → Options. This hides the Light entity for that fan (the integration reloads automatically). If you believe your fan *does* have a light that isn't working, please [open an issue](https://github.com/tjbaker/homeassistant-fansync/issues) with a downloaded diagnostics file so we can investigate device capabilities.
 
 #### Intermittent Disconnections
 

--- a/custom_components/fansync/__init__.py
+++ b/custom_components/fansync/__init__.py
@@ -32,12 +32,14 @@ from .const import (
     CONF_PASSWORD,
     CONF_VERIFY_SSL,
     CONF_WS_TIMEOUT,
+    DEFAULT_DISABLE_LIGHT,
     DEFAULT_FALLBACK_POLL_SECS,
     DEFAULT_HTTP_TIMEOUT_SECS,
     DEFAULT_WS_TIMEOUT_SECS,
     DOMAIN,
     KEY_LIGHT_BRIGHTNESS,
     KEY_LIGHT_POWER,
+    OPTION_DISABLE_LIGHT,
     OPTION_FALLBACK_POLL_SECS,
     PLATFORMS,
     POLL_STATUS_TIMEOUT_SECS,
@@ -183,18 +185,30 @@ async def async_setup_entry(hass: HomeAssistant, entry: FanSyncConfigEntry) -> b
         # Determine which platforms to load.
         # If no data yet (first refresh deferred or empty), fall back to all PLATFORMS
         # so that capability platforms (e.g., light) are available once data arrives.
+        # Users can hide a phantom light on lightless fans that still report a
+        # light channel (see OPTION_DISABLE_LIGHT).
+        disable_light = entry.options.get(OPTION_DISABLE_LIGHT, DEFAULT_DISABLE_LIGHT)
         data_now = coordinator.data
         if not isinstance(data_now, dict) or not data_now:
-            platforms = list(PLATFORMS)
+            platforms = ["fan"] if disable_light else list(PLATFORMS)
         else:
             platforms = ["fan"]
-            if any(
+            if not disable_light and any(
                 isinstance(s, dict) and (KEY_LIGHT_POWER in s or KEY_LIGHT_BRIGHTNESS in s)
                 for s in data_now.values()
             ):
                 platforms.append("light")
 
         async def _async_options_updated(hass: HomeAssistant, updated_entry: ConfigEntry) -> None:
+            # Toggling the light option adds/removes the light platform, which
+            # requires a full reload of the config entry to take effect.
+            new_disable_light = updated_entry.options.get(
+                OPTION_DISABLE_LIGHT, DEFAULT_DISABLE_LIGHT
+            )
+            if new_disable_light != disable_light:
+                await hass.config_entries.async_reload(updated_entry.entry_id)
+                return
+
             new_secs = updated_entry.options.get(
                 OPTION_FALLBACK_POLL_SECS, DEFAULT_FALLBACK_POLL_SECS
             )

--- a/custom_components/fansync/config_flow.py
+++ b/custom_components/fansync/config_flow.py
@@ -27,6 +27,7 @@ from .const import (
     CONF_PASSWORD,
     CONF_VERIFY_SSL,
     CONF_WS_TIMEOUT,
+    DEFAULT_DISABLE_LIGHT,
     DEFAULT_FALLBACK_POLL_SECS,
     DEFAULT_HTTP_TIMEOUT_SECS,
     DEFAULT_WS_TIMEOUT_SECS,
@@ -37,6 +38,7 @@ from .const import (
     MIN_FALLBACK_POLL_SECS,
     MIN_HTTP_TIMEOUT_SECS,
     MIN_WS_TIMEOUT_SECS,
+    OPTION_DISABLE_LIGHT,
     OPTION_FALLBACK_POLL_SECS,
 )
 
@@ -341,6 +343,9 @@ class FanSyncOptionsFlowHandler(config_entries.OptionsFlow):
                     OPTION_FALLBACK_POLL_SECS: secs,
                     CONF_HTTP_TIMEOUT: http_t,
                     CONF_WS_TIMEOUT: ws_t,
+                    OPTION_DISABLE_LIGHT: bool(
+                        user_input.get(OPTION_DISABLE_LIGHT, DEFAULT_DISABLE_LIGHT)
+                    ),
                 },
             )
 
@@ -355,12 +360,17 @@ class FanSyncOptionsFlowHandler(config_entries.OptionsFlow):
             CONF_WS_TIMEOUT,
             data_defaults.get(CONF_WS_TIMEOUT, DEFAULT_WS_TIMEOUT_SECS),
         )
+        current_disable_light = self._entry.options.get(OPTION_DISABLE_LIGHT, DEFAULT_DISABLE_LIGHT)
         schema = vol.Schema(
             {
                 vol.Optional(
                     OPTION_FALLBACK_POLL_SECS,
                     default=current,
                 ): vol.All(vol.Coerce(int), vol.Range(min=0, max=MAX_FALLBACK_POLL_SECS)),
+                vol.Optional(
+                    OPTION_DISABLE_LIGHT,
+                    default=current_disable_light,
+                ): bool,
                 vol.Optional(
                     CONF_HTTP_TIMEOUT,
                     default=current_http,

--- a/custom_components/fansync/const.py
+++ b/custom_components/fansync/const.py
@@ -49,6 +49,10 @@ OPTION_FALLBACK_POLL_SECS = "fallback_poll_seconds"
 DEFAULT_FALLBACK_POLL_SECS = 60
 MIN_FALLBACK_POLL_SECS = 15
 MAX_FALLBACK_POLL_SECS = 600
+# Options: hide the light entity for fans that have no physical light but still
+# advertise a light channel (H0B/H0C) in their status (e.g. some Kute60 units).
+OPTION_DISABLE_LIGHT = "disable_light"
+DEFAULT_DISABLE_LIGHT = False
 # Timeouts
 # HTTP timeouts apply to connect/read for login and token refresh
 DEFAULT_HTTP_TIMEOUT_SECS = 20

--- a/custom_components/fansync/diagnostics.py
+++ b/custom_components/fansync/diagnostics.py
@@ -89,7 +89,7 @@ async def async_get_config_entry_diagnostics(
                     profile = client.device_profile(device_id)
                     if profile:
                         # Include useful metadata, exclude sensitive data
-                        sanitized = {}
+                        sanitized: dict[str, Any] = {}
                         # Include the full esh block (device model / capability
                         # descriptor: brand, model, class, device_id, esh_version).
                         # It carries no secrets — the sensitive "cert" block is never

--- a/custom_components/fansync/diagnostics.py
+++ b/custom_components/fansync/diagnostics.py
@@ -90,11 +90,17 @@ async def async_get_config_entry_diagnostics(
                     if profile:
                         # Include useful metadata, exclude sensitive data
                         sanitized = {}
-                        if "esh" in profile:
-                            sanitized["esh"] = {
-                                "model": profile["esh"].get("model"),
-                                "brand": profile["esh"].get("brand"),
-                            }
+                        # Include the full esh block (device model / capability
+                        # descriptor: brand, model, class, device_id, esh_version).
+                        # It carries no secrets — the sensitive "cert" block is never
+                        # copied — and its fields help diagnose device-capability
+                        # issues (e.g. fans that advertise a light channel they lack).
+                        esh = profile.get("esh")
+                        if isinstance(esh, dict):
+                            sanitized["esh"] = dict(esh)
+                        # Surface which top-level profile blocks exist (not their
+                        # contents) so capability data outside esh is discoverable.
+                        sanitized["profile_keys"] = sorted(profile.keys())
                         if "module" in profile:
                             # Mask MAC address for privacy (show first 3 octets only)
                             mac = profile["module"].get("mac_address", "")

--- a/custom_components/fansync/translations/en.json
+++ b/custom_components/fansync/translations/en.json
@@ -36,11 +36,15 @@
     "step": {
       "init": {
         "title": "FanSync Options",
-        "description": "Configure fallback polling and network timeouts",
+        "description": "Configure fallback polling, network timeouts, and device options",
         "data": {
           "fallback_poll_seconds": "Fallback poll interval (seconds, 0 to disable)",
           "http_timeout_seconds": "HTTP timeout (seconds)",
-          "ws_timeout_seconds": "WebSocket timeout (seconds)"
+          "ws_timeout_seconds": "WebSocket timeout (seconds)",
+          "disable_light": "Fan has no light (hide the light entity)"
+        },
+        "data_description": {
+          "disable_light": "Enable this if your fan has no physical light but a Light entity still appears. Some models report a light channel they don't actually have. Changing this reloads the integration."
         }
       }
     }

--- a/custom_components/fansync/translations/es.json
+++ b/custom_components/fansync/translations/es.json
@@ -40,7 +40,11 @@
         "data": {
           "fallback_poll_seconds": "Intervalo de sondeo de respaldo (segundos, 0 para deshabilitar)",
           "http_timeout_seconds": "Tiempo de espera HTTP (segundos)",
-          "ws_timeout_seconds": "Tiempo de espera WebSocket (segundos)"
+          "ws_timeout_seconds": "Tiempo de espera WebSocket (segundos)",
+          "disable_light": "El ventilador no tiene luz (ocultar la entidad de luz)"
+        },
+        "data_description": {
+          "disable_light": "Habilite esto si su ventilador no tiene luz física pero aún aparece una entidad de luz. Algunos modelos informan un canal de luz que en realidad no tienen. Cambiar esto recarga la integración."
         }
       }
     }

--- a/custom_components/fansync/translations/fr.json
+++ b/custom_components/fansync/translations/fr.json
@@ -40,7 +40,11 @@
         "data": {
           "fallback_poll_seconds": "Intervalle d'interrogation de secours (secondes, 0 pour désactiver)",
           "http_timeout_seconds": "Délai HTTP (secondes)",
-          "ws_timeout_seconds": "Délai WebSocket (secondes)"
+          "ws_timeout_seconds": "Délai WebSocket (secondes)",
+          "disable_light": "Le ventilateur n'a pas de lumière (masquer l'entité lumière)"
+        },
+        "data_description": {
+          "disable_light": "Activez ceci si votre ventilateur n'a pas de lumière physique mais qu'une entité Lumière apparaît quand même. Certains modèles signalent un canal lumineux qu'ils n'ont pas réellement. Modifier ce paramètre recharge l'intégration."
         }
       }
     }

--- a/tests/test_disable_light.py
+++ b/tests/test_disable_light.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Trevor Baker, all rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The 'Fan has no light' option suppresses the phantom light entity."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.fansync.const import OPTION_DISABLE_LIGHT
+
+
+class LightCapableClient:
+    """Single device that reports a light channel (H0B/H0C)."""
+
+    def __init__(self):
+        self.status = {"H00": 1, "H02": 20, "H06": 0, "H01": 0, "H0B": 1, "H0C": 50}
+        self.device_ids = ["dev"]
+        self.device_id = "dev"
+
+    async def async_connect(self):
+        return None
+
+    async def async_disconnect(self):
+        return None
+
+    async def async_get_status(self, device_id: str | None = None):
+        return dict(self.status)
+
+    async def async_set(self, data: dict[str, int], *, device_id: str | None = None):
+        self.status.update(data)
+
+    def set_status_callback(self, cb):
+        self._cb = cb
+
+
+async def _setup(hass: HomeAssistant, options: dict) -> None:
+    entry = MockConfigEntry(
+        domain="fansync",
+        title="FanSync",
+        data={"email": "u@e.com", "password": "p", "verify_ssl": True},
+        options=options,
+        unique_id="disable-light",
+    )
+    entry.add_to_hass(hass)
+    with patch("custom_components.fansync.FanSyncClient", return_value=LightCapableClient()):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+
+def _entities(hass: HomeAssistant, domain: str) -> list[str]:
+    reg = er.async_get(hass)
+    return [
+        e.entity_id for e in reg.entities.values() if e.platform == "fansync" and e.domain == domain
+    ]
+
+
+async def test_light_created_by_default(hass: HomeAssistant) -> None:
+    """Without the option, a light-capable device gets a light entity."""
+    await _setup(hass, options={})
+    assert len(_entities(hass, "fan")) == 1
+    assert len(_entities(hass, "light")) == 1
+
+
+async def test_disable_light_suppresses_light_entity(hass: HomeAssistant) -> None:
+    """With disable_light=True, the light entity is not created (fan still is)."""
+    await _setup(hass, options={OPTION_DISABLE_LIGHT: True})
+    assert len(_entities(hass, "fan")) == 1
+    assert len(_entities(hass, "light")) == 0


### PR DESCRIPTION
## Summary

Follow-up to the Klute60 phantom-light investigation (tracked in #199). Two features + docs.

### feat: option to hide the Light entity on lightless fans
Some fans (e.g. certain Kute60 units) advertise a light channel (`H0B`/`H0C`) in their cloud status despite having **no physical light**, so the integration creates a non-functional `light.*` entity. Since the reported channel is indistinguishable from a real light, this adds a **"Fan has no light"** options toggle that suppresses the light platform for that config entry. Toggling it reloads the entry so the entity appears/disappears immediately. Localized (en/es/fr) with helper text.

- `const.py`: `OPTION_DISABLE_LIGHT` / `DEFAULT_DISABLE_LIGHT`
- `__init__.py`: skip the `light` platform when set; reload the entry when the option changes
- `config_flow.py`: boolean field in the options flow
- `translations/{en,es,fr}.json`: label + `data_description` (key parity maintained)
- `tests/test_disable_light.py`: default creates the light; toggle suppresses it (fan unaffected)

### feat: include the full `esh` block in diagnostics
Diagnostics now dump the complete `esh` (brand, model, `class`, `device_id`, `esh_version`) plus the list of top-level profile blocks, instead of only model/brand. `esh` carries no secrets (the sensitive `cert` block is never copied). This is what lets us gather device-capability data across models (see #199) to eventually auto-detect light capability and drop the manual toggle.

### docs
README gets the `disable_light` row in the Options table and a Troubleshooting entry explaining phantom lights and how to hide them.

## Verification
`make check` clean: **196 passed, 4 skipped**, ruff/black/mypy all pass; en/es/fr translation key-parity verified.

## Notes
Independent of 0.7.6 (already staged in #193) — this targets the release after. Relates to #199.