### PR TITLE
build: enforce Home Assistant 2026.6.0 minimum via HACS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Custom Home Assistant integration for Fanimation FanSync smart fans and lights. Uses WebSocket-based cloud push updates as the primary update mechanism with configurable fallback polling.
 
 - **Integration domain**: `fansync`
-- **HA minimum version**: 2026.3.0, Python 3.14+
+- **HA minimum version**: 2026.6.0, Python 3.14+ (enforced via `hacs.json`; latest-HA-only policy)
 - **IoT class**: `cloud_push`
 
 ## Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,4 +90,4 @@ type FanSyncConfigEntry = ConfigEntry[FanSyncRuntimeData]
 
 ### Testing
 
-Tests live in `tests/` (59 files). Mock at the import path used in the module under test, not the definition path. Coverage target is ≥75% for `custom_components/fansync`.
+Tests live in `tests/` (60+ files). Mock at the import path used in the module under test, not the definition path. Coverage target is ≥75% for `custom_components/fansync` (enforced in CI via `--cov-fail-under=75`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ A local Home Assistant instance for manual testing is available via `docker-comp
   - `fix:` → patch bump, appears in changelog; `feat:` → minor bump; `build:`/`chore:`/`docs:`/`test:`/`ci:` → no bump, not in changelog
   - When a PR mixes a code fix with a dep/tooling upgrade, use two commits (`fix:` first, then `build:`) so the fix lands in the changelog
 - All code must be fully type-annotated
+- **Editing/searching (Claude Code)**: prefer the Read/Grep/Edit tools over shell `grep`/`sed`/`cat`/`awk` — avoids permission prompts from glob/pipe expansion, gives cleaner reviewable diffs, and sidesteps shell-quoting bugs
 
 ## Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,7 +166,7 @@ Then manually install Home Assistant Core in development mode (see Home Assistan
 - **Formatter**: Black (line length 100) + Ruff
 - **Type checking**: mypy with strict settings  
 - **Python version**: 3.14
-- **Home Assistant**: 2026.3+
+- **Home Assistant**: 2026.6+
 - **Typing**: Modern syntax (`X | None` instead of `Optional[X]`)
 - **Async patterns**: Always use `async/await`, never block the event loop
 - **HA patterns**: CoordinatorEntity, push-first updates, optimistic UI

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Custom Home Assistant integration for Fanimation FanSync devices with cloud push
 ## Requirements
 
 - **Python:** 3.14+
-- **Home Assistant:** 2026.3.0 or newer
+- **Home Assistant:** 2026.6.0 or newer (HACS enforces this minimum)
 - **HACS:** Optional (only if installing via HACS)
 - **Account:** Valid Fanimation FanSync account with registered devices
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,5 @@
 {
   "name": "FanSync Home Assistant Integration",
-  "render_readme": true
+  "render_readme": true,
+  "homeassistant": "2026.6.0"
 }


### PR DESCRIPTION
## Summary

Makes the "latest Home Assistant only" support policy explicit and enforced.

The integration uses Python 3.14+ syntax (PEP 758 parenthesis-less `except`) and targets only current HA, which requires `Python >=3.14.2`. Previously the minimum was documented (CLAUDE.md) but **not enforced anywhere** — so users on older HA (e.g. 2026.2.1 / Python 3.13) could install it and hit a raw `SyntaxError` at import instead of a clear message. See discussion #186.

## Changes
- **`hacs.json`**: add `"homeassistant": "2026.6.0"` — HACS blocks installation on older HA and shows the requirement.
- **`README.md`** / **`CLAUDE.md`**: bump the documented minimum to 2026.6.0 and note it's enforced.

No runtime code changes.

## Verification
`hacs.json` parses; the HACS validation workflow will confirm the manifest/hacs metadata.

Relates to #186.