### PR TITLE
fix: make the "no light" option per-device instead of account-wide

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ Push-first updates are used by default. A low-frequency fallback poll can be con
 | fallback_poll_seconds  | Poll interval in seconds when push is unavailable (0 disables polling). | 60      |
 | http_timeout_seconds   | HTTP connect/read timeout (seconds)                               | 20      |
 | ws_timeout_seconds     | WebSocket connect/recv timeout (seconds)                          | 30      |
-| disable_light          | Hide the Light entity for a fan that has no physical light (see below). | off     |
+| lightless_devices      | Per-fan: select any fans with no physical light to hide their Light entity (see below). | none    |
 
 Set via: Settings → Devices & Services → FanSync → Configure → Options.
 - Poll interval allowed range: 15–600 seconds (0 disables polling and relies on push)
-- Changing **Fan has no light** reloads the integration so the Light entity appears/disappears immediately.
+- **Fans with no light** is a per-fan selection, so in a multi-fan account you can hide the phantom Light on only the fans that lack one. Changing it reloads the integration so the Light entities appear/disappear immediately.
 - Timeout ranges: 5–120 seconds (HTTP and WebSocket)
 
 ## Reauthentication
@@ -262,7 +262,7 @@ Then restart Home Assistant and reproduce the issue. Check logs in **Settings** 
 
 **Cause**: Some fans (e.g. certain Kute60 units) advertise a light channel in their cloud status despite having no bulb. The integration creates the Light entity from that reported channel, so it cannot tell a real light from a phantom one.
 
-**Solution**: Turn on **Fan has no light** in Settings → Devices & Services → FanSync → Configure → Options. This hides the Light entity for that fan (the integration reloads automatically). If you believe your fan *does* have a light that isn't working, please [open an issue](https://github.com/tjbaker/homeassistant-fansync/issues) with a downloaded diagnostics file so we can investigate device capabilities.
+**Solution**: In Settings → Devices & Services → FanSync → Configure → Options, select the affected fan(s) under **Fans with no light**. This hides the Light entity for just those fans (the integration reloads automatically) — other fans that do have lights are unaffected. If you believe your fan *does* have a light that isn't working, please [open an issue](https://github.com/tjbaker/homeassistant-fansync/issues) with a downloaded diagnostics file so we can investigate device capabilities.
 
 #### Intermittent Disconnections
 

--- a/custom_components/fansync/__init__.py
+++ b/custom_components/fansync/__init__.py
@@ -32,17 +32,16 @@ from .const import (
     CONF_PASSWORD,
     CONF_VERIFY_SSL,
     CONF_WS_TIMEOUT,
-    DEFAULT_DISABLE_LIGHT,
     DEFAULT_FALLBACK_POLL_SECS,
     DEFAULT_HTTP_TIMEOUT_SECS,
     DEFAULT_WS_TIMEOUT_SECS,
     DOMAIN,
     KEY_LIGHT_BRIGHTNESS,
     KEY_LIGHT_POWER,
-    OPTION_DISABLE_LIGHT,
     OPTION_FALLBACK_POLL_SECS,
     PLATFORMS,
     POLL_STATUS_TIMEOUT_SECS,
+    resolve_lightless_devices,
 )
 from .coordinator import FanSyncCoordinator
 
@@ -186,26 +185,30 @@ async def async_setup_entry(hass: HomeAssistant, entry: FanSyncConfigEntry) -> b
         # If no data yet (first refresh deferred or empty), fall back to all PLATFORMS
         # so that capability platforms (e.g., light) are available once data arrives.
         # Users can hide a phantom light on lightless fans that still report a
-        # light channel (see OPTION_DISABLE_LIGHT).
-        disable_light = entry.options.get(OPTION_DISABLE_LIGHT, DEFAULT_DISABLE_LIGHT)
+        # light channel; this is per-device (see resolve_lightless_devices).
+        known_ids = _get_client_device_ids(client)
+        lightless = resolve_lightless_devices(entry.options, known_ids)
         data_now = coordinator.data
         if not isinstance(data_now, dict) or not data_now:
-            platforms = ["fan"] if disable_light else list(PLATFORMS)
+            # No data yet: load the light platform unless every known device is
+            # marked lightless. light.py filters per-device once data arrives.
+            has_lit_device = not known_ids or any(d not in lightless for d in known_ids)
+            platforms = list(PLATFORMS) if has_lit_device else ["fan"]
         else:
             platforms = ["fan"]
-            if not disable_light and any(
-                isinstance(s, dict) and (KEY_LIGHT_POWER in s or KEY_LIGHT_BRIGHTNESS in s)
-                for s in data_now.values()
+            if any(
+                isinstance(s, dict)
+                and did not in lightless
+                and (KEY_LIGHT_POWER in s or KEY_LIGHT_BRIGHTNESS in s)
+                for did, s in data_now.items()
             ):
                 platforms.append("light")
 
         async def _async_options_updated(hass: HomeAssistant, updated_entry: ConfigEntry) -> None:
-            # Toggling the light option adds/removes the light platform, which
-            # requires a full reload of the config entry to take effect.
-            new_disable_light = updated_entry.options.get(
-                OPTION_DISABLE_LIGHT, DEFAULT_DISABLE_LIGHT
-            )
-            if new_disable_light != disable_light:
+            # Changing which devices are lightless adds/removes light entities,
+            # which requires a full reload of the config entry to take effect.
+            new_lightless = resolve_lightless_devices(updated_entry.options, known_ids)
+            if new_lightless != lightless:
                 await hass.config_entries.async_reload(updated_entry.entry_id)
                 return
 

--- a/custom_components/fansync/__init__.py
+++ b/custom_components/fansync/__init__.py
@@ -23,6 +23,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryError, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.typing import ConfigType
 
 from .client import FanSyncClient, FanSyncConfigError
@@ -72,6 +73,23 @@ def _get_client_device_ids(client: FanSyncClient) -> list[str]:
     """
     ids = getattr(client, "device_ids", []) or [getattr(client, "device_id", None)]
     return [i for i in ids if i]
+
+
+def _remove_lightless_light_entities(hass: HomeAssistant, lightless: set[str]) -> None:
+    """Remove registered light entities for devices the user marked lightless.
+
+    Otherwise the previously-created light entity lingers in the registry and HA
+    shows a "no longer provided by the integration" orphan warning.
+    """
+    if not lightless:
+        return
+    ent_reg = er.async_get(hass)
+    for device_id in lightless:
+        entity_id = ent_reg.async_get_entity_id("light", DOMAIN, f"{DOMAIN}_{device_id}_light")
+        if entity_id:
+            ent_reg.async_remove(entity_id)
+            if _LOGGER.isEnabledFor(logging.DEBUG):
+                _LOGGER.debug("removed hidden light entity %s (device marked lightless)", entity_id)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -188,6 +206,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: FanSyncConfigEntry) -> b
         # light channel; this is per-device (see resolve_lightless_devices).
         known_ids = _get_client_device_ids(client)
         lightless = resolve_lightless_devices(entry.options, known_ids)
+        # Remove any previously-registered light entities for now-lightless
+        # devices so HA doesn't leave an orphaned "no longer provided" entity.
+        _remove_lightless_light_entities(hass, lightless)
         data_now = coordinator.data
         if not isinstance(data_now, dict) or not data_now:
             # No data yet: load the light platform unless every known device is

--- a/custom_components/fansync/config_flow.py
+++ b/custom_components/fansync/config_flow.py
@@ -19,6 +19,8 @@ from typing import Any
 import httpx
 import voluptuous as vol
 from homeassistant import config_entries
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import device_registry as dr
 
 from .client import FanSyncClient
 from .const import (
@@ -27,7 +29,6 @@ from .const import (
     CONF_PASSWORD,
     CONF_VERIFY_SSL,
     CONF_WS_TIMEOUT,
-    DEFAULT_DISABLE_LIGHT,
     DEFAULT_FALLBACK_POLL_SECS,
     DEFAULT_HTTP_TIMEOUT_SECS,
     DEFAULT_WS_TIMEOUT_SECS,
@@ -38,8 +39,9 @@ from .const import (
     MIN_FALLBACK_POLL_SECS,
     MIN_HTTP_TIMEOUT_SECS,
     MIN_WS_TIMEOUT_SECS,
-    OPTION_DISABLE_LIGHT,
     OPTION_FALLBACK_POLL_SECS,
+    OPTION_LIGHTLESS_DEVICES,
+    resolve_lightless_devices,
 )
 
 DATA_SCHEMA = vol.Schema(
@@ -337,15 +339,17 @@ class FanSyncOptionsFlowHandler(config_entries.OptionsFlow):
                 else:
                     _LOGGER.debug("options poll interval set: %s", secs)
                 _LOGGER.debug("options timeouts set: http=%s ws=%s", http_t, ws_t)
+            lightless = user_input.get(
+                OPTION_LIGHTLESS_DEVICES,
+                self._entry.options.get(OPTION_LIGHTLESS_DEVICES, []),
+            )
             return self.async_create_entry(
                 title="FanSync Options",
                 data={
                     OPTION_FALLBACK_POLL_SECS: secs,
                     CONF_HTTP_TIMEOUT: http_t,
                     CONF_WS_TIMEOUT: ws_t,
-                    OPTION_DISABLE_LIGHT: bool(
-                        user_input.get(OPTION_DISABLE_LIGHT, DEFAULT_DISABLE_LIGHT)
-                    ),
+                    OPTION_LIGHTLESS_DEVICES: list(lightless),
                 },
             )
 
@@ -360,17 +364,28 @@ class FanSyncOptionsFlowHandler(config_entries.OptionsFlow):
             CONF_WS_TIMEOUT,
             data_defaults.get(CONF_WS_TIMEOUT, DEFAULT_WS_TIMEOUT_SECS),
         )
-        current_disable_light = self._entry.options.get(OPTION_DISABLE_LIGHT, DEFAULT_DISABLE_LIGHT)
-        schema = vol.Schema(
+        # Map this account's devices to friendly names for a per-device
+        # "no light" selection (the phantom-light option is per fan, not global).
+        device_map = self._device_name_map()
+        current_lightless = [
+            d
+            for d in resolve_lightless_devices(self._entry.options, list(device_map))
+            if d in device_map
+        ]
+
+        schema_dict: dict[Any, Any] = {
+            vol.Optional(
+                OPTION_FALLBACK_POLL_SECS,
+                default=current,
+            ): vol.All(vol.Coerce(int), vol.Range(min=0, max=MAX_FALLBACK_POLL_SECS)),
+        }
+        # Only offer the per-device selector when we know this account's devices.
+        if device_map:
+            schema_dict[vol.Optional(OPTION_LIGHTLESS_DEVICES, default=current_lightless)] = (
+                cv.multi_select(device_map)
+            )
+        schema_dict.update(
             {
-                vol.Optional(
-                    OPTION_FALLBACK_POLL_SECS,
-                    default=current,
-                ): vol.All(vol.Coerce(int), vol.Range(min=0, max=MAX_FALLBACK_POLL_SECS)),
-                vol.Optional(
-                    OPTION_DISABLE_LIGHT,
-                    default=current_disable_light,
-                ): bool,
                 vol.Optional(
                     CONF_HTTP_TIMEOUT,
                     default=current_http,
@@ -387,4 +402,15 @@ class FanSyncOptionsFlowHandler(config_entries.OptionsFlow):
                 ),
             }
         )
-        return self.async_show_form(step_id="init", data_schema=schema)
+        return self.async_show_form(step_id="init", data_schema=vol.Schema(schema_dict))
+
+    def _device_name_map(self) -> dict[str, str]:
+        """Map this entry's fansync device_ids to friendly names for the UI."""
+        dev_reg = dr.async_get(self.hass)
+        result: dict[str, str] = {}
+        for device in dr.async_entries_for_config_entry(dev_reg, self._entry.entry_id):
+            for domain, identifier in device.identifiers:
+                if domain == DOMAIN:
+                    result[identifier] = device.name_by_user or device.name or identifier
+                    break
+        return result

--- a/custom_components/fansync/config_flow.py
+++ b/custom_components/fansync/config_flow.py
@@ -405,12 +405,20 @@ class FanSyncOptionsFlowHandler(config_entries.OptionsFlow):
         return self.async_show_form(step_id="init", data_schema=vol.Schema(schema_dict))
 
     def _device_name_map(self) -> dict[str, str]:
-        """Map this entry's fansync device_ids to friendly names for the UI."""
+        """Map this entry's fansync device_ids to "name — model (serial)" labels."""
         dev_reg = dr.async_get(self.hass)
         result: dict[str, str] = {}
         for device in dr.async_entries_for_config_entry(dev_reg, self._entry.entry_id):
-            for domain, identifier in device.identifiers:
-                if domain == DOMAIN:
-                    result[identifier] = device.name_by_user or device.name or identifier
-                    break
+            identifier = next(
+                (ident for domain, ident in device.identifiers if domain == DOMAIN), None
+            )
+            if not identifier:
+                continue
+            name = device.name_by_user or device.name or "Fan"
+            label = (
+                f"{name} — {device.model} ({identifier})"
+                if device.model
+                else f"{name} ({identifier})"
+            )
+            result[identifier] = label
         return result

--- a/custom_components/fansync/const.py
+++ b/custom_components/fansync/const.py
@@ -10,6 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Iterable, Mapping
+
 DOMAIN = "fansync"
 PLATFORMS = ["fan", "light"]
 CONF_EMAIL = "email"
@@ -51,6 +53,10 @@ MIN_FALLBACK_POLL_SECS = 15
 MAX_FALLBACK_POLL_SECS = 600
 # Options: hide the light entity for fans that have no physical light but still
 # advertise a light channel (H0B/H0C) in their status (e.g. some Kute60 units).
+# Stored per-device: a list of device_ids whose light entity should be hidden.
+OPTION_LIGHTLESS_DEVICES = "lightless_devices"
+# Legacy account-wide boolean (0.8.0). Kept only for migration to the per-device
+# list above; a mixed multi-fan household could not use it correctly.
 OPTION_DISABLE_LIGHT = "disable_light"
 DEFAULT_DISABLE_LIGHT = False
 # Timeouts
@@ -122,3 +128,19 @@ def ha_brightness_to_pct(brightness: int | None) -> int:
 def pct_to_ha_brightness(pct: int) -> int:
     """Map FanSync 0-100 to Home Assistant brightness (0-255)."""
     return int(int(pct) * 255 / 100)
+
+
+def resolve_lightless_devices(options: Mapping[str, object], device_ids: Iterable[str]) -> set[str]:
+    """Return the device_ids whose light entity should be hidden.
+
+    Reads the per-device ``OPTION_LIGHTLESS_DEVICES`` list. If that key is not
+    set, migrates the legacy account-wide ``OPTION_DISABLE_LIGHT`` boolean
+    (0.8.0): when it was enabled, every known device is treated as lightless,
+    preserving the old behavior until the user re-picks per device.
+    """
+    explicit = options.get(OPTION_LIGHTLESS_DEVICES)
+    if isinstance(explicit, list):
+        return {str(d) for d in explicit if d}
+    if options.get(OPTION_DISABLE_LIGHT):
+        return {d for d in device_ids if d}
+    return set()

--- a/custom_components/fansync/device_utils.py
+++ b/custom_components/fansync/device_utils.py
@@ -27,6 +27,7 @@ def create_device_info(client: Any, device_id: str) -> DeviceInfo:
     device_id = device_id or "unknown"
     brand = "Fanimation"
     model = "FanSync"
+    name = "FanSync"
     sw: str | None = None
     mac: str | None = None
 
@@ -49,11 +50,26 @@ def create_device_info(client: Any, device_id: str) -> DeviceInfo:
         # Best-effort device info; ignore profile errors
         pass
 
+    # Prefer the user's display name from the account (e.g. "Living Room Fan")
+    # so multi-fan households get distinct, meaningful device names instead of
+    # every device showing as "FanSync".
+    try:
+        meta = client.device_metadata(device_id)
+        if isinstance(meta, dict):
+            props = meta.get("properties")
+            if isinstance(props, dict):
+                display = props.get("displayName")
+                if isinstance(display, str) and display.strip():
+                    name = display.strip()
+    except Exception:
+        # Best-effort; fall back to the generic name
+        pass
+
     info = DeviceInfo(
         identifiers={(DOMAIN, device_id)},
         manufacturer=brand,
         model=model,
-        name="FanSync",
+        name=name,
         sw_version=sw,
         serial_number=device_id,
     )

--- a/custom_components/fansync/light.py
+++ b/custom_components/fansync/light.py
@@ -30,6 +30,7 @@ from .const import (
     KEY_LIGHT_POWER,
     ha_brightness_to_pct,
     pct_to_ha_brightness,
+    resolve_lightless_devices,
 )
 from .coordinator import FanSyncCoordinator
 from .entity import FanSyncOptimisticEntity
@@ -65,9 +66,16 @@ async def async_setup_entry(
             # If refresh times out or fails, fall back to empty dict
             data = {}
 
-    # Create a light entity per device that reports light capability
+    # Devices the user marked as having no physical light (per-device option).
+    all_ids = getattr(client, "device_ids", []) or (list(data) if isinstance(data, dict) else [])
+    lightless = resolve_lightless_devices(entry.options, all_ids)
+
+    # Create a light entity per device that reports light capability and that the
+    # user has not marked as lightless.
     if isinstance(data, dict):
         for did, status in data.items():
+            if did in lightless:
+                continue
             if isinstance(status, dict) and (
                 KEY_LIGHT_POWER in status or KEY_LIGHT_BRIGHTNESS in status
             ):

--- a/custom_components/fansync/translations/en.json
+++ b/custom_components/fansync/translations/en.json
@@ -41,10 +41,10 @@
           "fallback_poll_seconds": "Fallback poll interval (seconds, 0 to disable)",
           "http_timeout_seconds": "HTTP timeout (seconds)",
           "ws_timeout_seconds": "WebSocket timeout (seconds)",
-          "disable_light": "Fan has no light (hide the light entity)"
+          "lightless_devices": "Fans with no light (hide their Light entity)"
         },
         "data_description": {
-          "disable_light": "Enable this if your fan has no physical light but a Light entity still appears. Some models report a light channel they don't actually have. Changing this reloads the integration."
+          "lightless_devices": "Select any fans that have no physical light. Some models report a light channel they don't actually have, creating a non-functional Light entity — checking a fan here hides its Light. Changing this reloads the integration."
         }
       }
     }

--- a/custom_components/fansync/translations/es.json
+++ b/custom_components/fansync/translations/es.json
@@ -41,10 +41,10 @@
           "fallback_poll_seconds": "Intervalo de sondeo de respaldo (segundos, 0 para deshabilitar)",
           "http_timeout_seconds": "Tiempo de espera HTTP (segundos)",
           "ws_timeout_seconds": "Tiempo de espera WebSocket (segundos)",
-          "disable_light": "El ventilador no tiene luz (ocultar la entidad de luz)"
+          "lightless_devices": "Ventiladores sin luz (ocultar su entidad de luz)"
         },
         "data_description": {
-          "disable_light": "Habilite esto si su ventilador no tiene luz física pero aún aparece una entidad de luz. Algunos modelos informan un canal de luz que en realidad no tienen. Cambiar esto recarga la integración."
+          "lightless_devices": "Seleccione los ventiladores que no tienen luz física. Algunos modelos informan un canal de luz que en realidad no tienen, creando una entidad de luz no funcional; marcar un ventilador aquí oculta su luz. Cambiar esto recarga la integración."
         }
       }
     }

--- a/custom_components/fansync/translations/fr.json
+++ b/custom_components/fansync/translations/fr.json
@@ -41,10 +41,10 @@
           "fallback_poll_seconds": "Intervalle d'interrogation de secours (secondes, 0 pour désactiver)",
           "http_timeout_seconds": "Délai HTTP (secondes)",
           "ws_timeout_seconds": "Délai WebSocket (secondes)",
-          "disable_light": "Le ventilateur n'a pas de lumière (masquer l'entité lumière)"
+          "lightless_devices": "Ventilateurs sans lumière (masquer leur entité Lumière)"
         },
         "data_description": {
-          "disable_light": "Activez ceci si votre ventilateur n'a pas de lumière physique mais qu'une entité Lumière apparaît quand même. Certains modèles signalent un canal lumineux qu'ils n'ont pas réellement. Modifier ce paramètre recharge l'intégration."
+          "lightless_devices": "Sélectionnez les ventilateurs qui n'ont pas de lumière physique. Certains modèles signalent un canal lumineux qu'ils n'ont pas réellement, créant une entité Lumière non fonctionnelle ; cocher un ventilateur ici masque sa Lumière. Modifier ce paramètre recharge l'intégration."
         }
       }
     }

--- a/tests/test_device_info_metadata.py
+++ b/tests/test_device_info_metadata.py
@@ -51,6 +51,9 @@ class MetaClient:
     def device_profile(self, device_id: str):
         return self._profile.get(device_id, {})
 
+    def device_metadata(self, device_id: str):
+        return {"device": device_id, "properties": {"displayName": "Living Room Fan"}}
+
 
 async def test_device_info_metadata(hass: HomeAssistant):
     client = MetaClient()
@@ -79,3 +82,5 @@ async def test_device_info_metadata(hass: HomeAssistant):
     assert dev.manufacturer == "Fanimation"
     assert dev.model == "OdynCustom-FDR1L2"
     assert dev.sw_version == "1.7.1"
+    # Device name comes from the account display name, not the generic "FanSync".
+    assert dev.name == "Living Room Fan"

--- a/tests/test_disable_light.py
+++ b/tests/test_disable_light.py
@@ -100,6 +100,31 @@ async def test_legacy_account_wide_bool_migrates_to_all(hass: HomeAssistant) -> 
     assert _light_devices(hass) == set()
 
 
+async def test_marking_lightless_removes_existing_light_entity(hass: HomeAssistant) -> None:
+    """Hiding a light removes its registry entry (no orphaned entity warning)."""
+    client = LightClient(["dev1"])
+    entry = MockConfigEntry(
+        domain="fansync",
+        title="FanSync",
+        data={"email": "u@e.com", "password": "p", "verify_ssl": True},
+        options={},
+        unique_id="lightless-remove",
+    )
+    entry.add_to_hass(hass)
+    with patch("custom_components.fansync.FanSyncClient", return_value=client):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        assert _light_devices(hass) == {"dev1"}
+
+        # Mark dev1 lightless -> reload -> stale light entity removed.
+        hass.config_entries.async_update_entry(entry, options={OPTION_LIGHTLESS_DEVICES: ["dev1"]})
+        await hass.async_block_till_done()
+
+    reg = er.async_get(hass)
+    assert reg.async_get_entity_id("light", "fansync", "fansync_dev1_light") is None
+    assert _light_devices(hass) == set()
+
+
 def test_resolve_lightless_devices() -> None:
     ids = ["a", "b", "c"]
     # Per-device list wins.

--- a/tests/test_disable_light.py
+++ b/tests/test_disable_light.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""The 'Fan has no light' option suppresses the phantom light entity."""
+"""Per-device 'Fan has no light' option suppresses the phantom light entity."""
 
 from __future__ import annotations
 
@@ -20,16 +20,22 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.fansync.const import OPTION_DISABLE_LIGHT
+from custom_components.fansync.const import (
+    OPTION_DISABLE_LIGHT,
+    OPTION_LIGHTLESS_DEVICES,
+    resolve_lightless_devices,
+)
 
 
-class LightCapableClient:
-    """Single device that reports a light channel (H0B/H0C)."""
+class LightClient:
+    """Multi-device client where every device reports a light channel."""
 
-    def __init__(self):
-        self.status = {"H00": 1, "H02": 20, "H06": 0, "H01": 0, "H0B": 1, "H0C": 50}
-        self.device_ids = ["dev"]
-        self.device_id = "dev"
+    def __init__(self, device_ids: list[str]):
+        self.device_ids = list(device_ids)
+        self.device_id = device_ids[0]
+        self.status_by_id = {
+            d: {"H00": 1, "H02": 20, "H06": 0, "H01": 0, "H0B": 1, "H0C": 50} for d in device_ids
+        }
 
     async def async_connect(self):
         return None
@@ -38,45 +44,72 @@ class LightCapableClient:
         return None
 
     async def async_get_status(self, device_id: str | None = None):
-        return dict(self.status)
+        did = device_id or self.device_ids[0]
+        return dict(self.status_by_id.get(did, {}))
 
     async def async_set(self, data: dict[str, int], *, device_id: str | None = None):
-        self.status.update(data)
+        self.status_by_id.get(device_id or self.device_id, {}).update(data)
 
     def set_status_callback(self, cb):
         self._cb = cb
 
 
-async def _setup(hass: HomeAssistant, options: dict) -> None:
+async def _setup(hass: HomeAssistant, client: LightClient, options: dict) -> None:
     entry = MockConfigEntry(
         domain="fansync",
         title="FanSync",
         data={"email": "u@e.com", "password": "p", "verify_ssl": True},
         options=options,
-        unique_id="disable-light",
+        unique_id="lightless",
     )
     entry.add_to_hass(hass)
-    with patch("custom_components.fansync.FanSyncClient", return_value=LightCapableClient()):
+    with patch("custom_components.fansync.FanSyncClient", return_value=client):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
 
-def _entities(hass: HomeAssistant, domain: str) -> list[str]:
+def _light_devices(hass: HomeAssistant) -> set[str]:
+    """device_ids that have a light entity (unique_id = fansync_<did>_light)."""
     reg = er.async_get(hass)
-    return [
-        e.entity_id for e in reg.entities.values() if e.platform == "fansync" and e.domain == domain
-    ]
+    out = set()
+    for e in reg.entities.values():
+        if e.platform == "fansync" and e.domain == "light" and e.unique_id:
+            out.add(e.unique_id[len("fansync_") : -len("_light")])
+    return out
 
 
 async def test_light_created_by_default(hass: HomeAssistant) -> None:
-    """Without the option, a light-capable device gets a light entity."""
-    await _setup(hass, options={})
-    assert len(_entities(hass, "fan")) == 1
-    assert len(_entities(hass, "light")) == 1
+    await _setup(hass, LightClient(["dev1"]), options={})
+    assert _light_devices(hass) == {"dev1"}
 
 
-async def test_disable_light_suppresses_light_entity(hass: HomeAssistant) -> None:
-    """With disable_light=True, the light entity is not created (fan still is)."""
-    await _setup(hass, options={OPTION_DISABLE_LIGHT: True})
-    assert len(_entities(hass, "fan")) == 1
-    assert len(_entities(hass, "light")) == 0
+async def test_lightless_device_hides_only_its_light(hass: HomeAssistant) -> None:
+    await _setup(hass, LightClient(["dev1"]), options={OPTION_LIGHTLESS_DEVICES: ["dev1"]})
+    assert _light_devices(hass) == set()
+
+
+async def test_per_device_selection_in_multi_fan_household(hass: HomeAssistant) -> None:
+    """dev1 marked lightless keeps dev2's light — the core multi-fan fix."""
+    await _setup(hass, LightClient(["dev1", "dev2"]), options={OPTION_LIGHTLESS_DEVICES: ["dev1"]})
+    assert _light_devices(hass) == {"dev2"}
+
+
+async def test_legacy_account_wide_bool_migrates_to_all(hass: HomeAssistant) -> None:
+    """The 0.8.0 account-wide disable_light=True migrates to every device."""
+    await _setup(hass, LightClient(["dev1", "dev2"]), options={OPTION_DISABLE_LIGHT: True})
+    assert _light_devices(hass) == set()
+
+
+def test_resolve_lightless_devices() -> None:
+    ids = ["a", "b", "c"]
+    # Per-device list wins.
+    assert resolve_lightless_devices({OPTION_LIGHTLESS_DEVICES: ["a", "c"]}, ids) == {"a", "c"}
+    # Empty list means "none", even if the legacy bool is set.
+    assert (
+        resolve_lightless_devices({OPTION_LIGHTLESS_DEVICES: [], OPTION_DISABLE_LIGHT: True}, ids)
+        == set()
+    )
+    # Legacy bool with no list migrates to all known devices.
+    assert resolve_lightless_devices({OPTION_DISABLE_LIGHT: True}, ids) == {"a", "b", "c"}
+    # Nothing set -> none.
+    assert resolve_lightless_devices({}, ids) == set()


### PR DESCRIPTION
## Summary

Fixes a design flaw in the 0.8.0 "Fan has no light" feature: the toggle lived on the **config entry** (which represents the whole Fanimation account), so in a multi-fan household it applied to **every** fan at once — you couldn't hide the phantom light on just the one lightless fan.

## Change

- **Per-device selection**: the options flow now shows a **"Fans with no light"** multi-select listing each fan by name; checking a fan hides only its Light entity. Stored as `OPTION_LIGHTLESS_DEVICES` (a list of device_ids).
- **`resolve_lightless_devices()`** (new helper in `const.py`) centralizes the logic; `__init__.py` and `light.py` use it to skip only the selected devices.
- **Reload-on-change** now compares the resolved per-device set.
- **Migration**: the legacy account-wide `disable_light: true` (0.8.0) is treated as "all devices lightless" until the user re-picks per fan, so existing setups don't regress.

## Tests
`tests/test_disable_light.py` rewritten: default creates the light; a lightless device hides only its own light; **multi-fan household hides one fan's light while keeping the other's**; legacy bool migrates to all; plus a `resolve_lightless_devices` unit test.

Full gate green: **199 passed, 4 skipped**, ruff/black/mypy clean, en/es/fr key-parity verified.

## Notes
This corrects the shipped 0.8.0 behavior, so it's a `fix:` → next patch release. Relates to #199.