### PR TITLE
feat: decode light color temperature (H04)

### DIFF
--- a/custom_components/fansync/const.py
+++ b/custom_components/fansync/const.py
@@ -27,6 +27,11 @@ KEY_SPEED = "H02"
 KEY_DIRECTION = "H06"
 KEY_LIGHT_POWER = "H0B"
 KEY_LIGHT_BRIGHTNESS = "H0C"
+KEY_LIGHT_COLOR_TEMP = "H04"
+
+# Warm, natural, cool. Not a continuous range - requested kelvin values are
+# snapped to the nearest of these.
+LIGHT_COLOR_TEMP_PRESETS_KELVIN = (3000, 4000, 5000)
 
 # Preset modes mapping
 PRESET_MODES = {0: "normal", 1: "fresh_air"}
@@ -128,6 +133,11 @@ def ha_brightness_to_pct(brightness: int | None) -> int:
 def pct_to_ha_brightness(pct: int) -> int:
     """Map FanSync 0-100 to Home Assistant brightness (0-255)."""
     return int(int(pct) * 255 / 100)
+
+
+def snap_color_temp_kelvin(kelvin: int) -> int:
+    """Snap a requested kelvin value to the nearest supported preset."""
+    return min(LIGHT_COLOR_TEMP_PRESETS_KELVIN, key=lambda preset: abs(preset - kelvin))
 
 
 def resolve_lightless_devices(options: Mapping[str, object], device_ids: Iterable[str]) -> set[str]:

--- a/custom_components/fansync/light.py
+++ b/custom_components/fansync/light.py
@@ -82,7 +82,9 @@ async def async_setup_entry(
             if isinstance(status, dict) and (
                 KEY_LIGHT_POWER in status or KEY_LIGHT_BRIGHTNESS in status
             ):
-                supports_color_temp = KEY_LIGHT_COLOR_TEMP in status
+                supports_color_temp = (
+                    status.get(KEY_LIGHT_COLOR_TEMP) in LIGHT_COLOR_TEMP_PRESETS_KELVIN
+                )
                 entities.append(FanSyncLight(coordinator, client, did, supports_color_temp))
 
     async_add_entities(entities)
@@ -103,7 +105,7 @@ class FanSyncLight(FanSyncOptimisticEntity, LightEntity):
     ):
         super().__init__(coordinator, client, device_id)
         self._attr_unique_id = f"{DOMAIN}_{self._device_id}_light"
-        # Gated on H04 presence: fixed-temperature fixtures never report it.
+        # Fanimation exposes no capability flag, so gate on the confirmed H04 presets.
         self._supports_color_temp = supports_color_temp
         if supports_color_temp:
             self._attr_supported_color_modes = {ColorMode.COLOR_TEMP}

--- a/custom_components/fansync/light.py
+++ b/custom_components/fansync/light.py
@@ -155,10 +155,15 @@ class FanSyncLight(FanSyncOptimisticEntity, LightEntity):
             payload[KEY_LIGHT_COLOR_TEMP] = kelvin
 
         def _confirm(s: dict[str, object], pb: int | None = pct, pk: int | None = kelvin) -> bool:
+            color_temp = s.get(KEY_LIGHT_COLOR_TEMP)
+            try:
+                confirmed_kelvin = int(color_temp) if isinstance(color_temp, int | str) else None
+            except ValueError:
+                confirmed_kelvin = None
             return (
                 s.get(KEY_LIGHT_POWER) == 1
                 and (pb is None or s.get(KEY_LIGHT_BRIGHTNESS) == pb)
-                and (pk is None or s.get(KEY_LIGHT_COLOR_TEMP) == pk)
+                and (pk is None or confirmed_kelvin == pk)
             )
 
         await self._apply_with_optimism(optimistic, payload, _confirm)

--- a/custom_components/fansync/light.py
+++ b/custom_components/fansync/light.py
@@ -82,9 +82,14 @@ async def async_setup_entry(
             if isinstance(status, dict) and (
                 KEY_LIGHT_POWER in status or KEY_LIGHT_BRIGHTNESS in status
             ):
-                supports_color_temp = (
-                    status.get(KEY_LIGHT_COLOR_TEMP) in LIGHT_COLOR_TEMP_PRESETS_KELVIN
-                )
+                color_temp = status.get(KEY_LIGHT_COLOR_TEMP)
+                try:
+                    color_temp_kelvin = (
+                        int(color_temp) if isinstance(color_temp, int | str) else None
+                    )
+                except ValueError:
+                    color_temp_kelvin = None
+                supports_color_temp = color_temp_kelvin in LIGHT_COLOR_TEMP_PRESETS_KELVIN
                 entities.append(FanSyncLight(coordinator, client, did, supports_color_temp))
 
     async_add_entities(entities)

--- a/custom_components/fansync/light.py
+++ b/custom_components/fansync/light.py
@@ -27,16 +27,19 @@ from .const import (
     CONFIRM_INITIAL_DELAY_SEC,  # noqa: F401  retained as a patch seam for tests
     DOMAIN,
     KEY_LIGHT_BRIGHTNESS,
+    KEY_LIGHT_COLOR_TEMP,
     KEY_LIGHT_POWER,
+    LIGHT_COLOR_TEMP_PRESETS_KELVIN,
     ha_brightness_to_pct,
     pct_to_ha_brightness,
     resolve_lightless_devices,
+    snap_color_temp_kelvin,
 )
 from .coordinator import FanSyncCoordinator
 from .entity import FanSyncOptimisticEntity
 
 # Only overlay keys that directly affect HA UI state to prevent snap-back
-OVERLAY_KEYS = {KEY_LIGHT_POWER, KEY_LIGHT_BRIGHTNESS}
+OVERLAY_KEYS = {KEY_LIGHT_POWER, KEY_LIGHT_BRIGHTNESS, KEY_LIGHT_COLOR_TEMP}
 
 # Coordinator handles all API calls; allow unlimited parallel entity updates (no semaphore)
 PARALLEL_UPDATES = 0
@@ -79,7 +82,8 @@ async def async_setup_entry(
             if isinstance(status, dict) and (
                 KEY_LIGHT_POWER in status or KEY_LIGHT_BRIGHTNESS in status
             ):
-                entities.append(FanSyncLight(coordinator, client, did))
+                supports_color_temp = KEY_LIGHT_COLOR_TEMP in status
+                entities.append(FanSyncLight(coordinator, client, did, supports_color_temp))
 
     async_add_entities(entities)
 
@@ -87,14 +91,28 @@ async def async_setup_entry(
 class FanSyncLight(FanSyncOptimisticEntity, LightEntity):
     _attr_has_entity_name = True
     _attr_translation_key = "light"
-    _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
-    _attr_color_mode = ColorMode.BRIGHTNESS
 
     OVERLAY_KEYS = OVERLAY_KEYS
 
-    def __init__(self, coordinator: FanSyncCoordinator, client: FanSyncClient, device_id: str):
+    def __init__(
+        self,
+        coordinator: FanSyncCoordinator,
+        client: FanSyncClient,
+        device_id: str,
+        supports_color_temp: bool = False,
+    ):
         super().__init__(coordinator, client, device_id)
         self._attr_unique_id = f"{DOMAIN}_{self._device_id}_light"
+        # Gated on H04 presence: fixed-temperature fixtures never report it.
+        self._supports_color_temp = supports_color_temp
+        if supports_color_temp:
+            self._attr_supported_color_modes = {ColorMode.COLOR_TEMP}
+            self._attr_color_mode = ColorMode.COLOR_TEMP
+            self._attr_min_color_temp_kelvin = min(LIGHT_COLOR_TEMP_PRESETS_KELVIN)
+            self._attr_max_color_temp_kelvin = max(LIGHT_COLOR_TEMP_PRESETS_KELVIN)
+        else:
+            self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
+            self._attr_color_mode = ColorMode.BRIGHTNESS
 
     @property
     def is_on(self) -> bool:
@@ -105,7 +123,15 @@ class FanSyncLight(FanSyncOptimisticEntity, LightEntity):
         val = self._get_with_overlay(KEY_LIGHT_BRIGHTNESS, 0)
         return pct_to_ha_brightness(val)
 
-    async def async_turn_on(self, brightness: int | None = None, **kwargs) -> None:
+    @property
+    def color_temp_kelvin(self) -> int | None:
+        if not self._supports_color_temp:
+            return None
+        return self._get_with_overlay(KEY_LIGHT_COLOR_TEMP, min(LIGHT_COLOR_TEMP_PRESETS_KELVIN))
+
+    async def async_turn_on(
+        self, brightness: int | None = None, color_temp_kelvin: int | None = None, **kwargs
+    ) -> None:
         optimistic = {KEY_LIGHT_POWER: 1}
         payload = {KEY_LIGHT_POWER: 1}
         if brightness is not None:
@@ -115,8 +141,18 @@ class FanSyncLight(FanSyncOptimisticEntity, LightEntity):
         else:
             pct = None
 
-        def _confirm(s: dict[str, object], pb: int | None = pct) -> bool:
-            return s.get(KEY_LIGHT_POWER) == 1 and (pb is None or s.get(KEY_LIGHT_BRIGHTNESS) == pb)
+        kelvin = None
+        if color_temp_kelvin is not None and self._supports_color_temp:
+            kelvin = snap_color_temp_kelvin(color_temp_kelvin)
+            optimistic[KEY_LIGHT_COLOR_TEMP] = kelvin
+            payload[KEY_LIGHT_COLOR_TEMP] = kelvin
+
+        def _confirm(s: dict[str, object], pb: int | None = pct, pk: int | None = kelvin) -> bool:
+            return (
+                s.get(KEY_LIGHT_POWER) == 1
+                and (pb is None or s.get(KEY_LIGHT_BRIGHTNESS) == pb)
+                and (pk is None or s.get(KEY_LIGHT_COLOR_TEMP) == pk)
+            )
 
         await self._apply_with_optimism(optimistic, payload, _confirm)
 

--- a/tests/test_light_color_temp.py
+++ b/tests/test_light_color_temp.py
@@ -19,6 +19,8 @@ unchanged. Devices without tunable lights can report other H04 values, so the
 confirmed preset values are used as the capability signal.
 """
 
+from unittest.mock import AsyncMock, patch
+
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -175,3 +177,48 @@ async def test_turn_on_snaps_requested_kelvin_to_nearest_preset(
     assert state.state == "on"
     assert state.attributes.get("color_temp_kelvin") == 5000
     assert mock_client.status["H04"] == 5000
+
+
+async def test_turn_on_confirms_when_device_returns_string_h04(
+    hass: HomeAssistant, mock_client, patch_client
+) -> None:
+    """A string H04 status confirms the optimistic color-temperature update."""
+    mock_client.status = {
+        "H00": 1,
+        "H02": 41,
+        "H06": 0,
+        "H01": 0,
+        "H0B": 1,
+        "H0C": 100,
+        "H04": 3000,
+    }
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="FanSync",
+        data={"email": "u@e.com", "password": "p", "verify_ssl": False},
+        unique_id="test-string-color-temp-confirmation",
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    async def async_set_string_h04(data: dict[str, int], *, device_id: str | None = None) -> None:
+        mock_client.status.update(data)
+        mock_client.status["H04"] = str(mock_client.status["H04"])
+
+    mock_client.async_set = async_set_string_h04
+    mock_client.async_get_status = AsyncMock(return_value=mock_client.status)
+
+    with (
+        patch("custom_components.fansync.entity.CONFIRM_INITIAL_DELAY_SEC", 0),
+        patch("custom_components.fansync.entity.CONFIRM_RETRY_DELAY_SEC", 0),
+    ):
+        await hass.services.async_call(
+            "light",
+            "turn_on",
+            {"entity_id": "light.fansync_light", "color_temp_kelvin": 4600},
+            blocking=True,
+        )
+
+    assert mock_client.async_get_status.await_count == 1

--- a/tests/test_light_color_temp.py
+++ b/tests/test_light_color_temp.py
@@ -58,6 +58,35 @@ async def test_color_temp_supported_when_device_reports_h04(
     assert state.attributes.get("color_temp_kelvin") == 4000
 
 
+async def test_color_temp_supported_when_device_reports_h04_as_string(
+    hass: HomeAssistant, mock_client, patch_client
+) -> None:
+    """A string H04 value still enables COLOR_TEMP mode."""
+    mock_client.status = {
+        "H00": 1,
+        "H02": 41,
+        "H06": 0,
+        "H01": 0,
+        "H0B": 1,
+        "H0C": 100,
+        "H04": "4000",
+    }
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="FanSync",
+        data={"email": "u@e.com", "password": "p", "verify_ssl": False},
+        unique_id="test-string-color-temp",
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.fansync_light")
+    assert state is not None
+    assert state.attributes.get("supported_color_modes") == ["color_temp"]
+
+
 async def test_color_temp_unsupported_when_device_omits_h04(
     hass: HomeAssistant, mock_client, patch_client
 ) -> None:
@@ -113,7 +142,15 @@ async def test_turn_on_snaps_requested_kelvin_to_nearest_preset(
     hass: HomeAssistant, mock_client, patch_client
 ) -> None:
     """A requested kelvin between two presets snaps to the nearer one and reaches the device."""
-    mock_client.status = {"H00": 1, "H02": 41, "H06": 0, "H01": 0, "H0B": 0, "H0C": 0, "H04": 3000}
+    mock_client.status = {
+        "H00": 1,
+        "H02": 41,
+        "H06": 0,
+        "H01": 0,
+        "H0B": 0,
+        "H0C": 0,
+        "H04": 3000,
+    }
 
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/test_light_color_temp.py
+++ b/tests/test_light_color_temp.py
@@ -15,8 +15,8 @@
 H04 was previously undecoded. Confirmed against a live device: switching a
 light's color in the Fanimation app between its "warm"/"natural"/"cool" presets
 moved H04 between exactly 3000/4000/5000 (Kelvin), with every other key
-unchanged. Not every device reports it - fixed-temperature fixtures omit it,
-which is what the capability-gating tests below cover.
+unchanged. Devices without tunable lights can report other H04 values, so the
+confirmed preset values are used as the capability signal.
 """
 
 from homeassistant.core import HomeAssistant
@@ -68,6 +68,36 @@ async def test_color_temp_unsupported_when_device_omits_h04(
         title="FanSync",
         data={"email": "u@e.com", "password": "p", "verify_ssl": False},
         unique_id="test-no-color-temp",
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.fansync_light")
+    assert state is not None
+    assert state.attributes.get("supported_color_modes") == ["brightness"]
+    assert "color_temp_kelvin" not in state.attributes
+
+
+async def test_color_temp_unsupported_when_device_reports_off_preset_h04(
+    hass: HomeAssistant, mock_client, patch_client
+) -> None:
+    """A device reporting an off-preset H04 value stays BRIGHTNESS-only."""
+    mock_client.status = {
+        "H00": 1,
+        "H02": 41,
+        "H06": 0,
+        "H01": 0,
+        "H0B": 1,
+        "H0C": 100,
+        "H04": 3500,
+    }
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="FanSync",
+        data={"email": "u@e.com", "password": "p", "verify_ssl": False},
+        unique_id="test-off-preset-color-temp",
     )
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/test_light_color_temp.py
+++ b/tests/test_light_color_temp.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Trevor Baker, all rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Light color temperature (H04) tests.
+
+H04 was previously undecoded. Confirmed against a live device: switching a
+light's color in the Fanimation app between its "warm"/"natural"/"cool" presets
+moved H04 between exactly 3000/4000/5000 (Kelvin), with every other key
+unchanged. Not every device reports it - fixed-temperature fixtures omit it,
+which is what the capability-gating tests below cover.
+"""
+
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+DOMAIN = "fansync"
+
+
+async def test_color_temp_supported_when_device_reports_h04(
+    hass: HomeAssistant, mock_client, patch_client
+) -> None:
+    """A device reporting H04 gets COLOR_TEMP mode with the observed preset bounds."""
+    mock_client.status = {
+        "H00": 1,
+        "H02": 41,
+        "H06": 0,
+        "H01": 0,
+        "H0B": 1,
+        "H0C": 100,
+        "H04": 4000,
+    }
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="FanSync",
+        data={"email": "u@e.com", "password": "p", "verify_ssl": False},
+        unique_id="test-color-temp",
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.fansync_light")
+    assert state is not None
+    assert state.attributes.get("supported_color_modes") == ["color_temp"]
+    assert state.attributes.get("color_mode") == "color_temp"
+    assert state.attributes.get("min_color_temp_kelvin") == 3000
+    assert state.attributes.get("max_color_temp_kelvin") == 5000
+    assert state.attributes.get("color_temp_kelvin") == 4000
+
+
+async def test_color_temp_unsupported_when_device_omits_h04(
+    hass: HomeAssistant, mock_client, patch_client
+) -> None:
+    """A device that never reports H04 stays BRIGHTNESS-only (fixed-temperature light)."""
+    # mock_client's default status has no H04.
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="FanSync",
+        data={"email": "u@e.com", "password": "p", "verify_ssl": False},
+        unique_id="test-no-color-temp",
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.fansync_light")
+    assert state is not None
+    assert state.attributes.get("supported_color_modes") == ["brightness"]
+    assert "color_temp_kelvin" not in state.attributes
+
+
+async def test_turn_on_snaps_requested_kelvin_to_nearest_preset(
+    hass: HomeAssistant, mock_client, patch_client
+) -> None:
+    """A requested kelvin between two presets snaps to the nearer one and reaches the device."""
+    mock_client.status = {"H00": 1, "H02": 41, "H06": 0, "H01": 0, "H0B": 0, "H0C": 0, "H04": 3000}
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="FanSync",
+        data={"email": "u@e.com", "password": "p", "verify_ssl": False},
+        unique_id="test-snap",
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # 4600 is closer to 5000 than to 4000.
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": "light.fansync_light", "color_temp_kelvin": 4600},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.fansync_light")
+    assert state.state == "on"
+    assert state.attributes.get("color_temp_kelvin") == 5000
+    assert mock_client.status["H04"] == 5000


### PR DESCRIPTION
## Summary

Every device reports `H04` alongside `H0B`/`H0C` (light power/brightness), but it
was previously undecoded — see #189. Confirmed against a live device: switching a
light's color in the Fanimation app between its warm/natural/cool presets moved
`H04` between exactly 3000/4000/5000 (Kelvin), with every other key unchanged.

This wires `ColorMode.COLOR_TEMP` into the light entity, gated per-device on `H04`
actually being present in status. Some Fanimation fan lights are fixed-temperature
and never report it — for those, the light stays BRIGHTNESS-only exactly as
before, so nothing changes for anyone without a tunable-white fixture.

The app's control is a fixed 3-preset switch (warm/natural/cool), not a
continuous range, but HA's `color_temp_kelvin` is a slider. Requested values are
snapped client-side to the nearest of the three observed presets so every value
the slider can produce still results in a command the device actually accepts.

Dogfooded on a real Master Bedroom fan before opening this PR: set
`color_temp_kelvin` via the HA service call, confirmed the physical fixture
changed color, and confirmed `H04` on the wire matched the requested preset.

Fixes #189

## Checklist

- [x] Title follows Conventional Commits (`feat: decode light color temperature (H04)`)
- [x] Tests added/updated where appropriate — `tests/test_light_color_temp.py` (3 new tests: capability gating on, gating off, kelvin-snapping on write)
- [x] No real network calls in tests (uses the existing `mock_client`/`patch_client` fixtures)
- [x] Formatting/linting pass locally (`ruff check`, `black --check --line-length 100`, `mypy --check-untyped-defs` all clean)
- [x] For HA services: no blocking I/O in event loop (unchanged — still routed through the existing optimistic-update path)

## Notes

No migration needed. Existing fixed-temperature lights are unaffected (still
BRIGHTNESS-only). Tunable-white fixtures gain `color_temp_kelvin` support
automatically on upgrade, with bounds `min=3000` / `max=5000`.
