### PR TITLE
chore(deps-dev): bump homeassistant 2026.8.3, phacc 0.13.357

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,13 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      # pytest-homeassistant-custom-component pins exact homeassistant and
+      # pytest* versions, so these must be bumped together in one PR.
+      homeassistant-test-stack:
+        patterns:
+          - "homeassistant"
+          - "pytest*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "FanSync Home Assistant Integration",
   "render_readme": true,
-  "homeassistant": "2026.6.0"
+  "homeassistant": "2026.8.0"
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,11 +12,11 @@
 
 # Development requirements for CI and local checks
 black==26.5.1
-homeassistant==2026.6.4
+homeassistant==2026.8.3
 mypy==2.1.0
 pycares==5.0.1
 pytest-cov==7.1.0
-pytest-homeassistant-custom-component==0.13.340
+pytest-homeassistant-custom-component==0.13.357
 pytest==9.0.3
 pre-commit==4.6.0
 ruff==0.15.12


### PR DESCRIPTION
## Summary

Supersedes #204, #206, and #208, which can't land individually:
`pytest-homeassistant-custom-component` pins **exact** versions of
`homeassistant` and `pytest`, so the stack only resolves when bumped in
lockstep. Verified locally in a fresh venv: install resolves cleanly, and
ruff / black / mypy / pytest all pass (200 passed, coverage 89.1%).

- `homeassistant` 2026.6.4 → **2026.8.3** (latest; #204 targeted the now-stale 2026.7.1)
- `pytest-homeassistant-custom-component` 0.13.340 → **0.13.357** (pins HA 2026.8.3, pytest 9.0.3)
- `pytest` stays at 9.0.3 — every phacc release through 0.13.357 pins it exactly, so #208 (9.1.1) is unsatisfiable
- `hacs.json` minimum → **2026.8.0** (latest-HA-only policy), as a separate `build:` commit
- dependabot: new `homeassistant-test-stack` group (`homeassistant` + `pytest*`) so future bumps of this stack arrive as one PR instead of three conflicting ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)