### PR TITLE
chore(deps-dev): drop pytest/pytest-cov pins managed by phacc

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,9 +15,9 @@ black==26.5.1
 homeassistant==2026.8.3
 mypy==2.3.1
 pycares==5.0.1
-pytest-cov==7.1.0
+# pytest and pytest-cov are intentionally unpinned: pytest-homeassistant-custom-component
+# pins exact versions of both, so pip resolves them from its requirements.
 pytest-homeassistant-custom-component==0.13.357
-pytest==9.0.3
 pre-commit==4.6.2
 ruff==0.15.20
 # Runtime deps required by integration (for local tests)


### PR DESCRIPTION
## Summary

`pytest-homeassistant-custom-component` pins **exact** versions of `pytest` and `pytest-cov`, so our own pins were redundant — and worse, they gave dependabot something to bump into unsatisfiable PRs (#208, and #213 via the new group). Removing the pins means:

- pip resolves both from phacc's requirements (verified in a fresh venv: unchanged — pytest 9.0.3, pytest-cov 7.1.0)
- dependabot has nothing to bump, so the forever-red pytest PRs stop
- future phacc bumps bring the matching pytest along automatically

Closes #213 as not-actionable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)