### PR TITLE
fix: include raw protocol values in diagnostics snapshots

### DIFF
--- a/custom_components/fansync/diagnostics_utils.py
+++ b/custom_components/fansync/diagnostics_utils.py
@@ -12,6 +12,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
 
 from .const import (
@@ -22,6 +23,13 @@ from .const import (
     KEY_PRESET,
     KEY_SPEED,
 )
+
+# Device protocol registers (H00, H0B, ...). Their raw values are plain fan/light
+# state — the same numbers the decoded fan/light summaries already expose — so
+# including them verbatim leaks nothing, and it lets user-supplied diagnostics
+# answer protocol questions about keys we have not decoded yet (see issue #189,
+# where redacted snapshots could not show which key carried color temperature).
+_PROTOCOL_KEY_RE = re.compile(r"^H[0-9A-F]{2}$")
 
 
 def summarize_status_snapshot(data: object | None) -> dict[str, dict[str, object]]:
@@ -38,6 +46,7 @@ def summarize_status_snapshot(data: object | None) -> dict[str, dict[str, object
         status_map = dict(status)
         summary[device_id] = {
             "keys": sorted(status_map.keys()),
+            "raw": {k: status_map[k] for k in sorted(status_map) if _PROTOCOL_KEY_RE.match(k)},
             "fan": {
                 "power": status_map.get(KEY_POWER),
                 "speed": status_map.get(KEY_SPEED),

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -167,6 +167,11 @@ async def test_diagnostics_returns_metrics(hass: HomeAssistant) -> None:
     assert diagnostics["coordinator"]["last_poll_mismatch_keys"]["test_device_123"] == ["H00"]
     assert diagnostics["coordinator"]["status_history"][0]["device_count"] == 1
 
+    # Verify raw protocol values survive into the snapshot (issue #189: without
+    # them, user-supplied diagnostics cannot show which undecoded key changed)
+    snapshot = diagnostics["coordinator"]["status_snapshot"]["test_device_123"]
+    assert snapshot["raw"] == {"H00": 1, "H02": 50}
+
     # Verify device IDs
     assert "test_device_123" in diagnostics["device_ids"]
 

--- a/tests/test_diagnostics_utils.py
+++ b/tests/test_diagnostics_utils.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Trevor Baker, all rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for diagnostics_utils.summarize_status_snapshot."""
+
+from custom_components.fansync.diagnostics_utils import summarize_status_snapshot
+
+
+def test_raw_includes_undecoded_protocol_keys() -> None:
+    """Undecoded registers (e.g. H04/H05/H0D/H0E) keep their values in `raw`.
+
+    Issue #189: diagnostics listed key names only, so user-supplied before/after
+    snapshots could not show which key carried color temperature.
+    """
+    data = {
+        "dev1": {
+            "H00": 1,
+            "H02": 41,
+            "H04": 3500,
+            "H05": 0,
+            "H0B": 1,
+            "H0C": 100,
+            "H0D": 0,
+            "H0E": 7,
+        }
+    }
+    summary = summarize_status_snapshot(data)
+    assert summary["dev1"]["raw"] == data["dev1"]
+    # Decoded summaries are unchanged
+    assert summary["dev1"]["fan"] == {"power": 1, "speed": 41, "preset": None, "direction": None}
+    assert summary["dev1"]["light"] == {"power": 1, "brightness": 100}
+
+
+def test_raw_excludes_non_protocol_keys() -> None:
+    """Only H-register keys are copied verbatim; anything else stays out of `raw`."""
+    data = {"dev1": {"H00": 1, "token": "secret", "Hxx": 5, "H123": 9}}
+    summary = summarize_status_snapshot(data)
+    assert summary["dev1"]["raw"] == {"H00": 1}
+    # Non-protocol keys still appear in the key listing for discoverability
+    assert summary["dev1"]["keys"] == ["H00", "H123", "Hxx", "token"]
+
+
+def test_summarize_handles_malformed_input() -> None:
+    """Non-mapping payloads and device entries are skipped, not raised."""
+    assert summarize_status_snapshot(None) == {}
+    assert summarize_status_snapshot("bogus") == {}
+    assert summarize_status_snapshot({"dev1": "bogus"}) == {}


### PR DESCRIPTION
## Summary

Diagnostics listed protocol key names but dropped their values, so user-supplied before/after snapshots couldn't show which undecoded register changed. Concretely, in #189 a user uploaded warm/natural/cool diagnostics exactly as asked and the three files were indistinguishable — the `H04` = 3000/4000/5000 discovery had to come from live-device testing instead (#211).

This adds a `raw` map of H-register values to each device's `status_snapshot` entry, and — since the coordinator's status history uses the same summarizer — to each `status_history` summary as well, making before/after uploads directly diffable.

**Privacy:** no new exposure. The decoded fan/light summaries already publish these same values under friendly names (power, speed, brightness); `raw` just stops discarding the registers we haven't decoded yet (`H04`/`H05`/`H0D`/`H0E`). Non-register keys are filtered by a strict `^H[0-9A-F]{2}$` match.

## Testing

- New `tests/test_diagnostics_utils.py`: raw includes undecoded registers, excludes non-protocol keys, malformed input handling
- Extended `tests/test_diagnostics.py` end-to-end assertion
- Full suite: 203 passed, coverage 89.2%

🤖 Generated with [Claude Code](https://claude.com/claude-code)