### PR TITLE
feat: auto-hide light on devices the cloud marks lightless

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,9 @@ Then restart Home Assistant and reproduce the issue. Check logs in **Settings** 
 
 **Cause**: Some fans (e.g. certain Kute60 units) advertise a light channel in their cloud status despite having no bulb. The integration creates the Light entity from that reported channel, so it cannot tell a real light from a phantom one.
 
-**Solution**: In Settings → Devices & Services → FanSync → Configure → Options, select the affected fan(s) under **Fans with no light**. This hides the Light entity for just those fans (the integration reloads automatically) — other fans that do have lights are unaffected. If you believe your fan *does* have a light that isn't working, please [open an issue](https://github.com/tjbaker/homeassistant-fansync/issues) with a downloaded diagnostics file so we can investigate device capabilities.
+**Automatic detection**: If you told the official Fanimation app that your fan has no light kit, the cloud marks the device accordingly (`hideLightDimmer`) and the integration hides the Light entity automatically — no configuration needed.
+
+**Manual option**: If the app was never told (the flag is only set when you configure it there), select the affected fan(s) under Settings → Devices & Services → FanSync → Configure → Options → **Fans with no light**. This hides the Light entity for just those fans (the integration reloads automatically) — other fans that do have lights are unaffected. If you believe your fan *does* have a light that isn't working, please [open an issue](https://github.com/tjbaker/homeassistant-fansync/issues) with a downloaded diagnostics file so we can investigate device capabilities.
 
 #### Intermittent Disconnections
 

--- a/custom_components/fansync/__init__.py
+++ b/custom_components/fansync/__init__.py
@@ -45,6 +45,7 @@ from .const import (
     resolve_lightless_devices,
 )
 from .coordinator import FanSyncCoordinator
+from .device_utils import cloud_lightless_devices
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -205,7 +206,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: FanSyncConfigEntry) -> b
         # Users can hide a phantom light on lightless fans that still report a
         # light channel; this is per-device (see resolve_lightless_devices).
         known_ids = _get_client_device_ids(client)
-        lightless = resolve_lightless_devices(entry.options, known_ids)
+        # Union of the user's explicit per-device option and devices the cloud
+        # itself marks lightless (properties.hideLightDimmer, see issue #199).
+        cloud_lightless = cloud_lightless_devices(client, known_ids)
+        lightless = resolve_lightless_devices(entry.options, known_ids) | cloud_lightless
         # Remove any previously-registered light entities for now-lightless
         # devices so HA doesn't leave an orphaned "no longer provided" entity.
         _remove_lightless_light_entities(hass, lightless)
@@ -228,7 +232,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: FanSyncConfigEntry) -> b
         async def _async_options_updated(hass: HomeAssistant, updated_entry: ConfigEntry) -> None:
             # Changing which devices are lightless adds/removes light entities,
             # which requires a full reload of the config entry to take effect.
-            new_lightless = resolve_lightless_devices(updated_entry.options, known_ids)
+            new_lightless = (
+                resolve_lightless_devices(updated_entry.options, known_ids) | cloud_lightless
+            )
             if new_lightless != lightless:
                 await hass.config_entries.async_reload(updated_entry.entry_id)
                 return

--- a/custom_components/fansync/device_utils.py
+++ b/custom_components/fansync/device_utils.py
@@ -13,13 +13,37 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import Any
 
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity import DeviceInfo
 
 from .const import DOMAIN
+
+
+def cloud_lightless_devices(client: Any, device_ids: Iterable[str]) -> set[str]:
+    """Return device_ids the Fanimation cloud marks as having no light kit.
+
+    The official app sets ``properties.hideLightDimmer`` to true on devices whose
+    owner told it no light kit is installed (issue #199). Observed across five
+    devices: true only ever appears on lightless fans, while light-equipped fans
+    report false or omit the key — but so do lightless fans whose owner never
+    told the app. So true is trusted as "no light"; absence proves nothing, and
+    the manual per-device option remains for the untagged case.
+    """
+    lightless: set[str] = set()
+    for device_id in device_ids:
+        try:
+            meta = client.device_metadata(device_id)
+        except Exception:
+            continue
+        if not isinstance(meta, dict):
+            continue
+        props = meta.get("properties")
+        if isinstance(props, dict) and props.get("hideLightDimmer") is True:
+            lightless.add(device_id)
+    return lightless
 
 
 def create_device_info(client: Any, device_id: str) -> DeviceInfo:

--- a/custom_components/fansync/light.py
+++ b/custom_components/fansync/light.py
@@ -33,6 +33,7 @@ from .const import (
     resolve_lightless_devices,
 )
 from .coordinator import FanSyncCoordinator
+from .device_utils import cloud_lightless_devices
 from .entity import FanSyncOptimisticEntity
 
 # Only overlay keys that directly affect HA UI state to prevent snap-back
@@ -66,9 +67,12 @@ async def async_setup_entry(
             # If refresh times out or fails, fall back to empty dict
             data = {}
 
-    # Devices the user marked as having no physical light (per-device option).
+    # Devices with no physical light: the user's per-device option plus devices
+    # the cloud marks lightless (properties.hideLightDimmer, see issue #199).
     all_ids = getattr(client, "device_ids", []) or (list(data) if isinstance(data, dict) else [])
-    lightless = resolve_lightless_devices(entry.options, all_ids)
+    lightless = resolve_lightless_devices(entry.options, all_ids) | cloud_lightless_devices(
+        client, all_ids
+    )
 
     # Create a light entity per device that reports light capability and that the
     # user has not marked as lightless.

--- a/tests/test_cloud_lightless.py
+++ b/tests/test_cloud_lightless.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Trevor Baker, all rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Auto-hide of lights on devices the cloud marks lightless (issue #199).
+
+The Fanimation app sets ``properties.hideLightDimmer: true`` on devices whose
+owner told it no light kit is installed. That is trusted as a "no light"
+signal and unioned with the user's explicit per-device option; absence or
+false changes nothing.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.fansync.const import OPTION_LIGHTLESS_DEVICES
+from custom_components.fansync.device_utils import cloud_lightless_devices
+
+
+class MetaLightClient:
+    """Multi-device client with light channels and per-device cloud metadata."""
+
+    def __init__(self, device_ids: list[str], metadata: dict[str, dict] | None = None):
+        self.device_ids = list(device_ids)
+        self.device_id = device_ids[0]
+        self._metadata = metadata or {}
+        self.status_by_id = {
+            d: {"H00": 1, "H02": 20, "H06": 0, "H01": 0, "H0B": 1, "H0C": 50} for d in device_ids
+        }
+
+    async def async_connect(self):
+        return None
+
+    async def async_disconnect(self):
+        return None
+
+    async def async_get_status(self, device_id: str | None = None):
+        did = device_id or self.device_ids[0]
+        return dict(self.status_by_id.get(did, {}))
+
+    async def async_set(self, data: dict[str, int], *, device_id: str | None = None):
+        self.status_by_id.get(device_id or self.device_id, {}).update(data)
+
+    def set_status_callback(self, cb):
+        self._cb = cb
+
+    def device_metadata(self, device_id: str) -> dict:
+        return self._metadata.get(device_id, {})
+
+
+async def _setup(hass: HomeAssistant, client: MetaLightClient, options: dict) -> None:
+    entry = MockConfigEntry(
+        domain="fansync",
+        title="FanSync",
+        data={"email": "u@e.com", "password": "p", "verify_ssl": True},
+        options=options,
+        unique_id="cloud-lightless",
+    )
+    entry.add_to_hass(hass)
+    with patch("custom_components.fansync.FanSyncClient", return_value=client):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+
+def _light_devices(hass: HomeAssistant) -> set[str]:
+    reg = er.async_get(hass)
+    out = set()
+    for e in reg.entities.values():
+        if e.platform == "fansync" and e.domain == "light" and e.unique_id:
+            out.add(e.unique_id[len("fansync_") : -len("_light")])
+    return out
+
+
+def test_cloud_lightless_devices_trusts_only_true() -> None:
+    """Only hideLightDimmer=true marks a device; false/absent/missing do not."""
+    client = MetaLightClient(
+        ["tagged", "explicit_false", "untagged", "no_meta"],
+        metadata={
+            "tagged": {"properties": {"hideLightDimmer": True}},
+            "explicit_false": {"properties": {"hideLightDimmer": False}},
+            "untagged": {"properties": {"displayName": "Fan"}},
+        },
+    )
+    assert cloud_lightless_devices(client, client.device_ids) == {"tagged"}
+
+
+def test_cloud_lightless_devices_tolerates_broken_client() -> None:
+    """A client without device_metadata (or raising) yields no detections."""
+
+    class NoMeta:
+        pass
+
+    class Raises:
+        def device_metadata(self, device_id: str) -> dict:
+            raise RuntimeError("boom")
+
+    assert cloud_lightless_devices(NoMeta(), ["dev1"]) == set()
+    assert cloud_lightless_devices(Raises(), ["dev1"]) == set()
+
+
+async def test_cloud_tagged_device_gets_no_light_entity(hass: HomeAssistant) -> None:
+    """hideLightDimmer=true auto-hides that device's light; others unaffected."""
+    client = MetaLightClient(
+        ["dev1", "dev2"],
+        metadata={"dev1": {"properties": {"hideLightDimmer": True}}},
+    )
+    await _setup(hass, client, options={})
+    assert _light_devices(hass) == {"dev2"}
+
+
+async def test_cloud_detection_unions_with_manual_option(hass: HomeAssistant) -> None:
+    """Cloud-tagged and manually-selected devices are both hidden."""
+    client = MetaLightClient(
+        ["dev1", "dev2", "dev3"],
+        metadata={"dev1": {"properties": {"hideLightDimmer": True}}},
+    )
+    await _setup(hass, client, options={OPTION_LIGHTLESS_DEVICES: ["dev2"]})
+    assert _light_devices(hass) == {"dev3"}
+
+
+async def test_false_or_absent_flag_keeps_light(hass: HomeAssistant) -> None:
+    """Devices with hideLightDimmer=false or no metadata keep their light."""
+    client = MetaLightClient(
+        ["dev1", "dev2"],
+        metadata={"dev1": {"properties": {"hideLightDimmer": False}}},
+    )
+    await _setup(hass, client, options={})
+    assert _light_devices(hass) == {"dev1", "dev2"}


### PR DESCRIPTION
## Summary

Implements the auto-detection investigated in #199, based on the data gathered there.

**Evidence (5 devices):** `esh` is a dead end — @devPalacio's two identical-model/firmware Kute5s (one with a light kit, one without) report identical `esh`. But `device_metadata.properties.hideLightDimmer` is a reliable one-way signal: `true` appears only on lightless fans (their Living Room Kute5), while light-equipped fans report `false` (the Levon Custom from #189) or omit it (their other two fans). Crucially, my own lightless Kute60 *also* omits it — the flag is only set when the owner tells the Fanimation app there's no light kit — so absence proves nothing.

**Design:** `true` ⇒ auto-hide that device's Light entity; the hidden set is the **union** of cloud-tagged devices and the existing `lightless_devices` option, which stays for untagged fans like mine. No migration; devices without the flag behave exactly as before.

## Changes

- `device_utils.py`: new `cloud_lightless_devices()` — tolerant of clients without metadata (returns empty set on any error)
- `__init__.py` / `light.py`: union cloud detection into the lightless set (platform selection, entity creation, orphan-entity cleanup, options-reload comparison)
- `tests/test_cloud_lightless.py`: 5 tests — trusts only `true`, tolerates broken clients, auto-hides tagged device, unions with manual option, keeps lights on false/absent
- README: troubleshooting section now documents automatic detection vs. the manual option

## Testing

Full suite: 208 passed, coverage 89.3%; ruff/black/mypy clean.

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)